### PR TITLE
Startup action

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import Control.Monad (forever)
 import Data.Maybe (fromMaybe)
 import Data.Text (pack)
 import LoadEnv (loadEnv)
@@ -8,7 +9,7 @@ import Tablebot (runTablebot)
 import Tablebot.Plugins (plugins)
 
 main :: IO ()
-main = do
+main = forever $ do
   loadEnv
   dToken <- pack <$> getEnv "DISCORD_TOKEN"
   prefix <- pack . fromMaybe "!" <$> lookupEnv "PREFIX"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,6 +8,7 @@ import System.Environment (getEnv, lookupEnv)
 import Tablebot (runTablebot)
 import Tablebot.Plugins (plugins)
 
+-- @main@ runs forever. This allows bot reloading by fully shutting down the bot and letting it restart.
 main :: IO ()
 main = forever $ do
   loadEnv

--- a/package.yaml
+++ b/package.yaml
@@ -50,6 +50,7 @@ dependencies:
 - exception-transformers
 - resourcet
 - resource-pool
+- containers
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -51,6 +51,7 @@ dependencies:
 - resourcet
 - resource-pool
 - containers
+- th-printf
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -49,6 +49,7 @@ dependencies:
 - data-default
 - exception-transformers
 - resourcet
+- resource-pool
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -48,6 +48,7 @@ dependencies:
 - http-client
 - data-default
 - exception-transformers
+- resourcet
 
 library:
   source-dirs: src

--- a/src/Tablebot.hs
+++ b/src/Tablebot.hs
@@ -79,9 +79,10 @@ runTablebot dToken prefix dbpath plugins =
           { discordToken = dToken,
             discordOnEvent =
               flip runSqlPool pool . eventHandler actions prefix,
-            discordOnStart =
+            discordOnStart = do
               -- Build list of cron jobs, saving them to the mvar.
-              runSqlPool (mapM runCron (compiledCronJobs actions) >>= liftIO . putMVar mvar) pool,
+              runSqlPool (mapM runCron (compiledCronJobs actions) >>= liftIO . putMVar mvar) pool
+              liftIO $ putStrLn "Tablebot lives!",
             -- Kill every cron job in the mvar.
             discordOnEnd = takeMVar mvar >>= killCron
           }

--- a/src/Tablebot.hs
+++ b/src/Tablebot.hs
@@ -25,6 +25,7 @@ import Control.Concurrent
   )
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.Logger (NoLoggingT (runNoLoggingT))
+import Control.Monad.Trans.Resource (runResourceT)
 import Data.Text (Text, pack)
 import qualified Data.Text.IO as TIO (putStrLn)
 import Database.Persist.Sqlite
@@ -34,6 +35,7 @@ import Database.Persist.Sqlite
   )
 import Discord
 import Tablebot.Handler (eventHandler, killCron, runCron)
+import Tablebot.Handler.Administration (adminMigration, currentBlacklist, removeBlacklisted)
 import Tablebot.Plugin (Plugin, combinePlugins, cronJobs, migrations)
 import Tablebot.Plugin.Help
 import Tablebot.Plugin.Utils (debugPrint)
@@ -50,26 +52,31 @@ import Tablebot.Plugin.Utils (debugPrint)
 -- bot close.
 runTablebot :: Text -> Text -> FilePath -> [Plugin] -> IO ()
 runTablebot dToken prefix dbpath plugins =
-  let !plugin = generateHelp $ combinePlugins plugins
-   in do
-        debugPrint ("DEBUG enabled. This is strongly not recommended in production!" :: String)
-        -- Create multiple database threads.
-        pool <- runNoLoggingT $ createSqlitePool (pack dbpath) 8
-        -- TODO: this might have issues with duplicates?
-        -- TODO: in production, this should probably run once and then never again.
-        mapM_ (\migration -> runSqlPool (runMigration migration) pool) $ migrations plugin
-        -- Create a var to kill any ongoing tasks.
-        mvar <- newEmptyMVar :: IO (MVar [ThreadId])
-        userFacingError <-
-          runDiscord $
-            def
-              { discordToken = dToken,
-                discordOnEvent =
-                  flip runSqlPool pool . eventHandler plugin prefix,
-                discordOnStart =
-                  -- Build list of cron jobs, saving them to the mvar.
-                  runSqlPool (mapM runCron (cronJobs plugin) >>= liftIO . putMVar mvar) pool,
-                -- Kill every cron job in the mvar.
-                discordOnEnd = takeMVar mvar >>= killCron
-              }
-        TIO.putStrLn userFacingError
+  do
+    debugPrint ("DEBUG enabled. This is strongly not recommended in production!" :: String)
+    -- Create multiple database threads.
+    pool <- runNoLoggingT $ createSqlitePool (pack dbpath) 8
+
+    -- Setup and then apply plugin blacklist from the database
+    runSqlPool (runMigration adminMigration) pool
+    blacklist <- runResourceT $ runNoLoggingT $ runSqlPool currentBlacklist pool
+    let !plugin = generateHelp $ combinePlugins (removeBlacklisted blacklist plugins)
+
+    -- TODO: this might have issues with duplicates?
+    -- TODO: in production, this should probably run once and then never again.
+    mapM_ (\migration -> runSqlPool (runMigration migration) pool) $ migrations plugin
+    -- Create a var to kill any ongoing tasks.
+    mvar <- newEmptyMVar :: IO (MVar [ThreadId])
+    userFacingError <-
+      runDiscord $
+        def
+          { discordToken = dToken,
+            discordOnEvent =
+              flip runSqlPool pool . eventHandler plugin prefix,
+            discordOnStart =
+              -- Build list of cron jobs, saving them to the mvar.
+              runSqlPool (mapM runCron (cronJobs plugin) >>= liftIO . putMVar mvar) pool,
+            -- Kill every cron job in the mvar.
+            discordOnEnd = takeMVar mvar >>= killCron
+          }
+    TIO.putStrLn userFacingError

--- a/src/Tablebot/Handler/Administration.hs
+++ b/src/Tablebot/Handler/Administration.hs
@@ -1,4 +1,8 @@
-module Tablebot.Handler.Administration where
+module Tablebot.Handler.Administration
+  ( module Tablebot.Handler.Administration,
+    CompiledPlugin, -- Exfiltrate this to the admin plugin
+  )
+where
 
 import Data.Text (Text, pack)
 import Database.Persist
@@ -27,4 +31,4 @@ currentBlacklist = do
 removeBlacklisted :: [Text] -> [CompiledPlugin] -> [CompiledPlugin]
 removeBlacklisted bl p = filter isNotBlacklisted p
   where
-    isNotBlacklisted p' = not (compliedName p' `elem` bl)
+    isNotBlacklisted p' = not (compiledName p' `elem` bl)

--- a/src/Tablebot/Handler/Administration.hs
+++ b/src/Tablebot/Handler/Administration.hs
@@ -18,7 +18,7 @@ PluginBlacklist
     deriving Show
 |]
 
-currentBlacklist :: SqlPersistM ([Text])
+currentBlacklist :: SqlPersistM [Text]
 currentBlacklist = do
   bl <- selectList allBlacklisted []
   return $ fmap (pack . pluginBlacklistLabel . unentity) bl

--- a/src/Tablebot/Handler/Administration.hs
+++ b/src/Tablebot/Handler/Administration.hs
@@ -21,12 +21,10 @@ PluginBlacklist
 currentBlacklist :: SqlPersistM [Text]
 currentBlacklist = do
   bl <- selectList allBlacklisted []
-  return $ fmap (pack . pluginBlacklistLabel . unentity) bl
+  return $ fmap (pack . pluginBlacklistLabel . entityVal) bl
   where
     allBlacklisted :: [Filter PluginBlacklist]
     allBlacklisted = []
-    unentity :: (Entity a) -> a
-    unentity a = entityVal a
 
 removeBlacklisted :: [Text] -> [CompiledPlugin] -> [CompiledPlugin]
 removeBlacklisted bl p = filter isNotBlacklisted p

--- a/src/Tablebot/Handler/Administration.hs
+++ b/src/Tablebot/Handler/Administration.hs
@@ -1,0 +1,30 @@
+module Tablebot.Handler.Administration where
+
+import Data.Text (Text, pack)
+import Database.Persist
+import Database.Persist.Sqlite (SqlPersistM)
+import Database.Persist.TH
+import Tablebot.Plugin.Types (Plugin, pluginName)
+
+share
+  [mkPersist sqlSettings, mkMigrate "adminMigration"]
+  [persistLowerCase|
+PluginBlacklist
+    label String
+    deriving Show
+|]
+
+currentBlacklist :: SqlPersistM ([Text])
+currentBlacklist = do
+  bl <- selectList allBlacklisted []
+  return $ fmap (pack . pluginBlacklistLabel . unentity) bl
+  where
+    allBlacklisted :: [Filter PluginBlacklist]
+    allBlacklisted = []
+    unentity :: (Entity a) -> a
+    unentity a = entityVal a
+
+removeBlacklisted :: [Text] -> [Plugin] -> [Plugin]
+removeBlacklisted bl p = filter isNotBlacklisted p
+  where
+    isNotBlacklisted p' = not (pluginName p' `elem` bl)

--- a/src/Tablebot/Handler/Administration.hs
+++ b/src/Tablebot/Handler/Administration.hs
@@ -4,7 +4,7 @@ import Data.Text (Text, pack)
 import Database.Persist
 import Database.Persist.Sqlite (SqlPersistM)
 import Database.Persist.TH
-import Tablebot.Plugin.Types (Plugin, pluginName)
+import Tablebot.Handler.Types
 
 share
   [mkPersist sqlSettings, mkMigrate "adminMigration"]
@@ -24,7 +24,7 @@ currentBlacklist = do
     unentity :: (Entity a) -> a
     unentity a = entityVal a
 
-removeBlacklisted :: [Text] -> [Plugin] -> [Plugin]
+removeBlacklisted :: [Text] -> [CompiledPlugin] -> [CompiledPlugin]
 removeBlacklisted bl p = filter isNotBlacklisted p
   where
-    isNotBlacklisted p' = not (pluginName p' `elem` bl)
+    isNotBlacklisted p' = not (compliedName p' `elem` bl)

--- a/src/Tablebot/Handler/Command.hs
+++ b/src/Tablebot/Handler/Command.hs
@@ -18,20 +18,22 @@ where
 
 import Data.Text (Text, isPrefixOf)
 import Discord.Types (Message (messageText))
-import Tablebot.Plugin
+import Tablebot.Handler.Plugins (changeAction)
+import Tablebot.Handler.Types
 import Tablebot.Plugin.Discord (sendEmbedMessage)
 import Tablebot.Plugin.Exception (BotException (ParserException), embedError)
 import Tablebot.Plugin.Parser (skipSpace1)
+import Tablebot.Plugin.Types hiding (commandParser, inlineCommandParser)
 import Text.Megaparsec
 
 -- | @parseNewMessage@ parses a new message, first by attempting to match the
 -- bot's prefix to the start of the message, then (if that fails) by attempting
 -- to find inline commands.
-parseNewMessage :: Plugin -> Text -> Message -> DatabaseDiscord ()
+parseNewMessage :: PluginActions -> Text -> Message -> CompiledDatabaseDiscord ()
 parseNewMessage pl prefix m =
   if prefix `isPrefixOf` messageText m
-    then parseCommands (commands pl) m prefix
-    else parseInlineCommands (inlineCommands pl) m
+    then parseCommands (compiledCommands pl) m prefix
+    else parseInlineCommands (compiledInlineCommands pl) m
 
 -- | Given a list of 'Command' @cs@, the 'Message' that triggered the event
 -- @m@, and a command prefix @prefix@, construct a parser that parses commands.
@@ -41,27 +43,27 @@ parseNewMessage pl prefix m =
 --
 -- If the parser errors, the last error (which is hopefully one created by
 -- '<?>') is sent to the user as a Discord message.
-parseCommands :: [Command] -> Message -> Text -> DatabaseDiscord ()
+parseCommands :: [CompiledCommand] -> Message -> Text -> CompiledDatabaseDiscord ()
 parseCommands cs m prefix = case parse (parser cs) "" (messageText m) of
   Right p -> p m
-  Left e -> sendEmbedMessage m "" $ embedError $ ParserException $ "```\n" ++ errorBundlePretty e ++ "```"
+  Left e -> changeAction () . sendEmbedMessage m "" $ embedError $ ParserException $ "```\n" ++ errorBundlePretty e ++ "```"
   where
-    parser :: [Command] -> Parser (Message -> DatabaseDiscord ())
+    parser :: [CompiledCommand] -> Parser (Message -> CompiledDatabaseDiscord ())
     parser cs' =
       do
         _ <- chunk prefix
         choice (map toErroringParser cs') <?> "No command with that name was found!"
         <|> pure (\_ -> pure ())
-    toErroringParser :: Command -> Parser (Message -> DatabaseDiscord ())
-    toErroringParser c = try (chunk $ name c) *> (skipSpace1 <|> eof) *> commandParser c
+    toErroringParser :: CompiledCommand -> Parser (Message -> CompiledDatabaseDiscord ())
+    toErroringParser c = try (chunk $ commandName c) *> (skipSpace1 <|> eof) *> commandParser c
 
 -- | Given a list of 'InlineCommand' @cs@ and a message @m@, run each inline
 -- command's parser on the message text until one succeeds. Errors are not sent
 -- to the user, and do not halt command attempts (achieved using 'try').
-parseInlineCommands :: [InlineCommand] -> Message -> DatabaseDiscord ()
+parseInlineCommands :: [CompiledInlineCommand] -> Message -> CompiledDatabaseDiscord ()
 parseInlineCommands cs m = case parse (parser cs) "" (messageText m) of
   Right p -> p m
   Left _ -> pure ()
   where
-    parser :: [InlineCommand] -> Parser (Message -> DatabaseDiscord ())
+    parser :: [CompiledInlineCommand] -> Parser (Message -> CompiledDatabaseDiscord ())
     parser cs' = choice $ map (try . inlineCommandParser) cs'

--- a/src/Tablebot/Handler/Event.hs
+++ b/src/Tablebot/Handler/Event.hs
@@ -17,32 +17,32 @@ module Tablebot.Handler.Event
 where
 
 import Discord.Types
-import Tablebot.Plugin.Types
+import Tablebot.Handler.Types
 
 -- | This runs each 'MessageChange' feature in @cs@ with the information from a
 -- Discord 'MessageUpdate' or 'MessageDelete' event - whether it is an update
 -- or delete (the bool @updated@), the 'ChannelId' @cid@, and the 'MessageId'
 -- @mid@.
 parseMessageChange ::
-  [MessageChange] ->
+  [CompiledMessageChange] ->
   Bool ->
   ChannelId ->
   MessageId ->
-  DatabaseDiscord ()
+  CompiledDatabaseDiscord ()
 parseMessageChange cs updated cid mid = mapM_ doMessageChange cs
   where
     doMessageChange c = onMessageChange c updated cid mid
 
 -- | This runs each 'ReactionAdd' feature in @cs@ with the information from a
 -- Discord 'MessageReactionAdd' event provided as 'ReactionInfo' @info@.
-parseReactionAdd :: [ReactionAdd] -> ReactionInfo -> DatabaseDiscord ()
+parseReactionAdd :: [CompiledReactionAdd] -> ReactionInfo -> CompiledDatabaseDiscord ()
 parseReactionAdd cs info = mapM_ doReactionAdd cs
   where
     doReactionAdd c = onReactionAdd c info
 
 -- | This runs each 'ReactionDel' feature in @cs@ with the information from
 -- a Discord 'MessageReactionRemove' event provided as 'ReactionInfo' @info@.
-parseReactionDel :: [ReactionDel] -> ReactionInfo -> DatabaseDiscord ()
+parseReactionDel :: [CompiledReactionDel] -> ReactionInfo -> CompiledDatabaseDiscord ()
 parseReactionDel cs info = mapM_ doReactionAdd cs
   where
     doReactionAdd c = onReactionDelete c info
@@ -50,7 +50,7 @@ parseReactionDel cs info = mapM_ doReactionAdd cs
 -- | This runs each 'Other' feature in @cs@ with the Discord 'Event' provided.
 -- Note that any events covered by other feature types will /not/ be run
 -- through this.
-parseOther :: [Other] -> Event -> DatabaseDiscord ()
+parseOther :: [CompiledOther] -> Event -> CompiledDatabaseDiscord ()
 parseOther cs ev = mapM_ doOther cs
   where
     doOther c = onOtherEvent c ev

--- a/src/Tablebot/Handler/Permission.hs
+++ b/src/Tablebot/Handler/Permission.hs
@@ -13,7 +13,6 @@ module Tablebot.Handler.Permission where
 import Control.Monad.IO.Class (liftIO)
 import Discord.Types (GuildMember, Message, RoleId, memberRoles)
 import System.Environment (lookupEnv)
-import Tablebot.Handler.Types
 import Tablebot.Plugin.Discord (getMessageMember)
 import Tablebot.Plugin.Types
 import Tablebot.Plugin.Utils (isDebug)
@@ -59,7 +58,7 @@ permsFromGroups debug krls gps =
     elemish (Just a) b = a `elem` b
     elemish Nothing _ = False
 
-getSenderPermission :: Message -> DatabaseDiscord s UserPermission
+getSenderPermission :: Message -> EnvDatabaseDiscord s UserPermission
 getSenderPermission m = do
   member <- getMessageMember m
   knownroles <- liftIO getKnownRoles

--- a/src/Tablebot/Handler/Permission.hs
+++ b/src/Tablebot/Handler/Permission.hs
@@ -13,6 +13,7 @@ module Tablebot.Handler.Permission where
 import Control.Monad.IO.Class (liftIO)
 import Discord.Types (GuildMember, Message, RoleId, memberRoles)
 import System.Environment (lookupEnv)
+import Tablebot.Handler.Types
 import Tablebot.Plugin.Discord (getMessageMember)
 import Tablebot.Plugin.Types
 import Tablebot.Plugin.Utils (isDebug)
@@ -58,7 +59,7 @@ permsFromGroups debug krls gps =
     elemish (Just a) b = a `elem` b
     elemish Nothing _ = False
 
-getSenderPermission :: Message -> DatabaseDiscord UserPermission
+getSenderPermission :: Message -> DatabaseDiscord s UserPermission
 getSenderPermission m = do
   member <- getMessageMember m
   knownroles <- liftIO getKnownRoles

--- a/src/Tablebot/Handler/Plugins.hs
+++ b/src/Tablebot/Handler/Plugins.hs
@@ -1,0 +1,89 @@
+-- |
+-- Module      : Tablebot.Handler.Plugins
+-- Description : Some internal code for handling plugins
+-- License     : MIT
+-- Maintainer  : finnjkeating@gmail.com
+-- Stability   : experimental
+-- Portability : POSIX
+--
+-- This contains some functions to combine and compile plugins
+module Tablebot.Handler.Plugins where
+
+import Control.Monad.Trans.Reader (runReaderT)
+import Discord.Types (Message)
+import Tablebot.Handler.Types hiding (helpPages, migrations)
+import qualified Tablebot.Handler.Types as HT
+import Tablebot.Plugin.Types
+
+-- | Combines a list of plugins into a single plugin with the combined
+-- functionality. The bot actually runs a single plugin, which is just the
+-- combined version of all input plugins.
+combinePlugins :: [CompiledPlugin] -> CombinedPlugin
+combinePlugins [] = CmPl [] [] []
+combinePlugins (p : ps) =
+  let p' = combinePlugins ps
+   in CmPl
+        { combinedSetupAction = setupAction p : combinedSetupAction p',
+          combinedMigrations = HT.migrations p ++ combinedMigrations p',
+          combinedHelpPages = HT.helpPages p ++ combinedHelpPages p'
+        }
+
+-- | Combines a list of plugins actions into a single pa with the combined
+-- functionality.
+combineActions :: [PluginActions] -> PluginActions
+combineActions [] = PA [] [] [] [] [] [] []
+combineActions (p : ps) =
+  let p' = combineActions ps
+   in PA
+        { compiledCommands = compiledCommands p +++ compiledCommands p',
+          compiledInlineCommands = compiledInlineCommands p +++ compiledInlineCommands p',
+          compiledOnMessageChanges = compiledOnMessageChanges p +++ compiledOnMessageChanges p',
+          compiledOnReactionAdds = compiledOnReactionAdds p +++ compiledOnReactionAdds p',
+          compiledOnReactionDeletes = compiledOnReactionDeletes p +++ compiledOnReactionDeletes p',
+          compiledOtherEvents = compiledOtherEvents p +++ compiledOtherEvents p',
+          compiledCronJobs = compiledCronJobs p +++ compiledCronJobs p'
+        }
+  where
+    -- copy across Finnbar's +++ optimisation for empty lists from the old system, as it applies here.
+    [] +++ [] = []
+    a +++ [] = a
+    [] +++ a = a
+    a +++ b = a ++ b
+
+compilePlugin :: Plugin b -> CompiledPlugin
+compilePlugin p = CPl (pluginName p) sa (helpPages p) (migrations p)
+  where
+    sa :: Database PluginActions
+    sa = do
+      state <- startAction (startUp p)
+
+      return $
+        PA
+          (map (fixCommand state) $ commands p)
+          (map (fixInlineCommand state) $ inlineCommands p)
+          (map (fixOnMessageChanges state) $ onMessageChanges p)
+          (map (fixOnReactionAdd state) $ onReactionAdds p)
+          (map (fixOnReactionDelete state) $ onReactionDeletes p)
+          (map (fixOther state) $ otherEvents p)
+          (map (fixCron state) $ cronJobs p)
+
+    -- Command converters
+    fixCommand state' (Command name' action') = CCommand name' (compileParser state' action')
+    fixInlineCommand state' (InlineCommand action') = CInlineCommand (compileParser state' action')
+    fixOnMessageChanges state' (MessageChange action') = CMessageChange (((changeAction state' .) .) . action')
+    fixOnReactionAdd state' (ReactionAdd action') = CReactionAdd (changeAction state' . action')
+    fixOnReactionDelete state' (ReactionDel action') = CReactionDel (changeAction state' . action')
+    fixOther state' (Other action') = COther (changeAction state' . action')
+    fixCron state' (CronJob time action') = CCronJob time (changeAction state' action')
+
+-- * Helper converters
+
+-- |
+compileParser :: s -> Parser (Message -> DatabaseDiscord s a) -> Parser (Message -> CompiledDatabaseDiscord a)
+compileParser s = fmap (changeMessageAction s)
+
+changeMessageAction :: s -> (Message -> DatabaseDiscord s a) -> Message -> CompiledDatabaseDiscord a
+changeMessageAction s action message = runReaderT (action message) s
+
+changeAction :: s -> DatabaseDiscord s a -> CompiledDatabaseDiscord a
+changeAction s action = runReaderT action s

--- a/src/Tablebot/Handler/Plugins.hs
+++ b/src/Tablebot/Handler/Plugins.hs
@@ -50,7 +50,7 @@ combineActions (p : ps) =
     [] +++ a = a
     a +++ b = a ++ b
 
-compilePlugin :: Plugin b -> CompiledPlugin
+compilePlugin :: EnvPlugin b -> CompiledPlugin
 compilePlugin p = CPl (pluginName p) sa (helpPages p) (migrations p)
   where
     sa :: Database PluginActions
@@ -79,11 +79,11 @@ compilePlugin p = CPl (pluginName p) sa (helpPages p) (migrations p)
 -- * Helper converters
 
 -- |
-compileParser :: s -> Parser (Message -> DatabaseDiscord s a) -> Parser (Message -> CompiledDatabaseDiscord a)
+compileParser :: s -> Parser (Message -> EnvDatabaseDiscord s a) -> Parser (Message -> CompiledDatabaseDiscord a)
 compileParser s = fmap (changeMessageAction s)
 
-changeMessageAction :: s -> (Message -> DatabaseDiscord s a) -> Message -> CompiledDatabaseDiscord a
+changeMessageAction :: s -> (Message -> EnvDatabaseDiscord s a) -> Message -> CompiledDatabaseDiscord a
 changeMessageAction s action message = runReaderT (action message) s
 
-changeAction :: s -> DatabaseDiscord s a -> CompiledDatabaseDiscord a
+changeAction :: s -> EnvDatabaseDiscord s a -> CompiledDatabaseDiscord a
 changeAction s action = runReaderT action s

--- a/src/Tablebot/Handler/Types.hs
+++ b/src/Tablebot/Handler/Types.hs
@@ -1,0 +1,80 @@
+-- |
+-- Module      : Tablebot.Handler.Types
+-- Description : Non-public types used throughout the rest of the implementation.
+-- License     : MIT
+-- Maintainer  : tagarople@gmail.com
+-- Stability   : experimental
+-- Portability : POSIX
+--
+-- All of the important types used throughout the implementation that aren't exposed to plugins.
+-- Defines a @CompiledPlugin@, which represents a compiled and unified form of a plugin to
+-- allow homogeneous storage throughout the rest of the implementation.
+module Tablebot.Handler.Types where
+
+import Data.Text (Text)
+import Database.Persist.Sqlite (Migration, SqlPersistT)
+import Discord
+import Discord.Types
+import Tablebot.Plugin.Types
+
+type CompiledDatabaseDiscord = SqlPersistT DiscordHandler
+
+-- | @CompiledPlugin@ represents the internal format of the plugins.
+-- Its main job is to convert all the plugins into one type by collapsing
+-- it down to a single action that returns the respective actions
+data CompiledPlugin = CPl
+  { compliedName :: Text,
+    setupAction :: Database PluginActions,
+    helpPages :: [HelpPage],
+    migrations :: [Migration]
+  }
+
+data PluginActions = PA
+  { compiledCommands :: [CompiledCommand],
+    compiledInlineCommands :: [CompiledInlineCommand],
+    compiledOnMessageChanges :: [CompiledMessageChange],
+    compiledOnReactionAdds :: [CompiledReactionAdd],
+    compiledOnReactionDeletes :: [CompiledReactionDel],
+    compiledOtherEvents :: [CompiledOther],
+    compiledCronJobs :: [CompiledCronJob]
+  }
+
+data CombinedPlugin = CmPl
+  { combinedSetupAction :: [Database PluginActions],
+    combinedHelpPages :: [HelpPage],
+    combinedMigrations :: [Migration]
+  }
+
+-- * Compiled Items
+
+-- These are compiled forms of the actions from the public types that remove the reader.
+
+data CompiledCommand = CCommand
+  { commandName :: Text,
+    commandParser :: Parser (Message -> CompiledDatabaseDiscord ())
+  }
+
+newtype CompiledInlineCommand = CInlineCommand
+  { inlineCommandParser :: Parser (Message -> CompiledDatabaseDiscord ())
+  }
+
+newtype CompiledMessageChange = CMessageChange
+  { onMessageChange :: Bool -> ChannelId -> MessageId -> CompiledDatabaseDiscord ()
+  }
+
+newtype CompiledReactionAdd = CReactionAdd
+  { onReactionAdd :: ReactionInfo -> CompiledDatabaseDiscord ()
+  }
+
+newtype CompiledReactionDel = CReactionDel
+  { onReactionDelete :: ReactionInfo -> CompiledDatabaseDiscord ()
+  }
+
+newtype CompiledOther = COther
+  { onOtherEvent :: Event -> CompiledDatabaseDiscord ()
+  }
+
+data CompiledCronJob = CCronJob
+  { timeframe :: Int,
+    onCron :: CompiledDatabaseDiscord ()
+  }

--- a/src/Tablebot/Handler/Types.hs
+++ b/src/Tablebot/Handler/Types.hs
@@ -23,7 +23,7 @@ type CompiledDatabaseDiscord = SqlPersistT DiscordHandler
 -- Its main job is to convert all the plugins into one type by collapsing
 -- it down to a single action that returns the respective actions
 data CompiledPlugin = CPl
-  { compliedName :: Text,
+  { compiledName :: Text,
     setupAction :: Database PluginActions,
     helpPages :: [HelpPage],
     migrations :: [Migration]

--- a/src/Tablebot/Plugin/Database.hs
+++ b/src/Tablebot/Plugin/Database.hs
@@ -1,0 +1,103 @@
+module Tablebot.Plugin.Database
+  ( module Tablebot.Plugin.Database,
+    Sql.fromSqlKey,
+    Sql.toSqlKey,
+    liftSql,
+  )
+where
+
+import Data.Int (Int64)
+import Data.Map
+import Data.Text (Text)
+import qualified Database.Persist.Sqlite as Sql
+import Tablebot.Plugin (DatabaseDiscord, liftSql)
+
+insert :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> DatabaseDiscord d (Sql.Key record)
+insert r = liftSql $ Sql.insert r
+
+insert_ :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> DatabaseDiscord d ()
+insert_ r = liftSql $ Sql.insert_ r
+
+insertMany :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [record] -> DatabaseDiscord d [Sql.Key record]
+insertMany r = liftSql $ Sql.insertMany r
+
+insertMany_ :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [record] -> DatabaseDiscord d ()
+insertMany_ r = liftSql $ Sql.insertMany_ r
+
+insertEntityMany :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Entity record] -> DatabaseDiscord d ()
+insertEntityMany r = liftSql $ Sql.insertEntityMany r
+
+insertEntity :: (Sql.PersistEntity e, Sql.PersistEntityBackend e ~ Sql.SqlBackend) => e -> DatabaseDiscord d (Sql.Entity e)
+insertEntity r = liftSql $ Sql.insertEntity r
+
+insertEntityUnique :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> DatabaseDiscord d (Maybe (Sql.Entity record))
+insertEntityUnique r = liftSql $ Sql.insertUniqueEntity r
+
+insertUnique :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> DatabaseDiscord d (Maybe (Sql.Key record))
+insertUnique r = liftSql $ Sql.insertUnique r
+
+delete :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Key record -> DatabaseDiscord d ()
+delete r = liftSql $ Sql.delete r
+
+deleteBy :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Unique record -> DatabaseDiscord d ()
+deleteBy r = liftSql $ Sql.deleteBy r
+
+deleteCascade :: Sql.DeleteCascade record Sql.SqlBackend => Sql.Key record -> DatabaseDiscord d ()
+deleteCascade r = liftSql $ Sql.deleteCascade r
+
+deleteCascadeWhere :: Sql.DeleteCascade record Sql.SqlBackend => [Sql.Filter record] -> DatabaseDiscord d ()
+deleteCascadeWhere r = liftSql $ Sql.deleteCascadeWhere r
+
+deleteWhereCount :: (Sql.PersistEntity val, Sql.PersistEntityBackend val ~ Sql.SqlBackend) => [Sql.Filter val] -> DatabaseDiscord d Int64
+deleteWhereCount r = liftSql $ Sql.deleteWhereCount r
+
+update :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Key record -> [Sql.Update record] -> DatabaseDiscord d ()
+update r v = liftSql $ Sql.update r v
+
+updateWhere :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> [Sql.Update record] -> DatabaseDiscord d ()
+updateWhere r v = liftSql $ Sql.updateWhere r v
+
+updateWhereCount :: (Sql.PersistEntity val, Sql.PersistEntityBackend val ~ Sql.SqlBackend) => [Sql.Filter val] -> [Sql.Update val] -> DatabaseDiscord d Int64
+updateWhereCount r v = liftSql $ Sql.updateWhereCount r v
+
+updateGet :: (Sql.PersistEntity a, Sql.PersistEntityBackend a ~ Sql.SqlBackend) => Sql.Key a -> [Sql.Update a] -> DatabaseDiscord d a
+updateGet r v = liftSql $ Sql.updateGet r v
+
+upsert :: (Sql.OnlyOneUniqueKey record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> [Sql.Update record] -> DatabaseDiscord d (Sql.Entity record)
+upsert r v = liftSql $ Sql.upsert r v
+
+count :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> DatabaseDiscord d Int
+count r = liftSql $ Sql.count r
+
+selectFirst :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> [Sql.SelectOpt record] -> DatabaseDiscord d (Maybe (Sql.Entity record))
+selectFirst r v = liftSql $ Sql.selectFirst r v
+
+selectKeysList :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> [Sql.SelectOpt record] -> DatabaseDiscord d [Sql.Key record]
+selectKeysList r v = liftSql $ Sql.selectKeysList r v
+
+selectList :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> [Sql.SelectOpt record] -> DatabaseDiscord d [Sql.Entity record]
+selectList r v = liftSql $ Sql.selectList r v
+
+get :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Key record -> DatabaseDiscord d (Maybe record)
+get v = liftSql $ Sql.get v
+
+getBy :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Unique record -> DatabaseDiscord d (Maybe (Sql.Entity record))
+getBy v = liftSql $ Sql.getBy v
+
+getByValue :: (Sql.AtLeastOneUniqueKey record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> DatabaseDiscord d (Maybe (Sql.Entity record))
+getByValue v = liftSql $ Sql.getByValue v
+
+getEntity :: (Sql.PersistEntity e, Sql.PersistEntityBackend e ~ Sql.SqlBackend) => Sql.Key e -> DatabaseDiscord d (Maybe (Sql.Entity e))
+getEntity v = liftSql $ Sql.getEntity v
+
+getFieldName :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.EntityField record typ -> DatabaseDiscord d Text
+getFieldName v = liftSql $ Sql.getFieldName v
+
+getJust :: (Sql.PersistEntity a, Sql.PersistEntityBackend a ~ Sql.SqlBackend) => Sql.Key a -> DatabaseDiscord d a
+getJust v = liftSql $ Sql.getJust v
+
+getJustEntity :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Key record -> DatabaseDiscord d (Sql.Entity record)
+getJustEntity v = liftSql $ Sql.getJustEntity v
+
+getMany :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Key record] -> DatabaseDiscord d (Map (Sql.Key record) record)
+getMany v = liftSql $ Sql.getMany v

--- a/src/Tablebot/Plugin/Database.hs
+++ b/src/Tablebot/Plugin/Database.hs
@@ -10,97 +10,97 @@ import Data.Int (Int64)
 import Data.Map
 import Data.Text (Text)
 import qualified Database.Persist.Sqlite as Sql
-import Tablebot.Plugin (DatabaseDiscord, liftSql)
+import Tablebot.Plugin (EnvDatabaseDiscord, liftSql)
 
-insert :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> DatabaseDiscord d (Sql.Key record)
+insert :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> EnvDatabaseDiscord d (Sql.Key record)
 insert r = liftSql $ Sql.insert r
 
-insert_ :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> DatabaseDiscord d ()
+insert_ :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> EnvDatabaseDiscord d ()
 insert_ r = liftSql $ Sql.insert_ r
 
-insertMany :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [record] -> DatabaseDiscord d [Sql.Key record]
+insertMany :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [record] -> EnvDatabaseDiscord d [Sql.Key record]
 insertMany r = liftSql $ Sql.insertMany r
 
-insertMany_ :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [record] -> DatabaseDiscord d ()
+insertMany_ :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [record] -> EnvDatabaseDiscord d ()
 insertMany_ r = liftSql $ Sql.insertMany_ r
 
-insertEntityMany :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Entity record] -> DatabaseDiscord d ()
+insertEntityMany :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Entity record] -> EnvDatabaseDiscord d ()
 insertEntityMany r = liftSql $ Sql.insertEntityMany r
 
-insertEntity :: (Sql.PersistEntity e, Sql.PersistEntityBackend e ~ Sql.SqlBackend) => e -> DatabaseDiscord d (Sql.Entity e)
+insertEntity :: (Sql.PersistEntity e, Sql.PersistEntityBackend e ~ Sql.SqlBackend) => e -> EnvDatabaseDiscord d (Sql.Entity e)
 insertEntity r = liftSql $ Sql.insertEntity r
 
-insertEntityUnique :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> DatabaseDiscord d (Maybe (Sql.Entity record))
+insertEntityUnique :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> EnvDatabaseDiscord d (Maybe (Sql.Entity record))
 insertEntityUnique r = liftSql $ Sql.insertUniqueEntity r
 
-insertUnique :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> DatabaseDiscord d (Maybe (Sql.Key record))
+insertUnique :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> EnvDatabaseDiscord d (Maybe (Sql.Key record))
 insertUnique r = liftSql $ Sql.insertUnique r
 
-delete :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Key record -> DatabaseDiscord d ()
+delete :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Key record -> EnvDatabaseDiscord d ()
 delete r = liftSql $ Sql.delete r
 
-deleteBy :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Unique record -> DatabaseDiscord d ()
+deleteBy :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Unique record -> EnvDatabaseDiscord d ()
 deleteBy r = liftSql $ Sql.deleteBy r
 
-deleteCascade :: Sql.DeleteCascade record Sql.SqlBackend => Sql.Key record -> DatabaseDiscord d ()
+deleteCascade :: Sql.DeleteCascade record Sql.SqlBackend => Sql.Key record -> EnvDatabaseDiscord d ()
 deleteCascade r = liftSql $ Sql.deleteCascade r
 
-deleteCascadeWhere :: Sql.DeleteCascade record Sql.SqlBackend => [Sql.Filter record] -> DatabaseDiscord d ()
+deleteCascadeWhere :: Sql.DeleteCascade record Sql.SqlBackend => [Sql.Filter record] -> EnvDatabaseDiscord d ()
 deleteCascadeWhere r = liftSql $ Sql.deleteCascadeWhere r
 
-deleteWhereCount :: (Sql.PersistEntity val, Sql.PersistEntityBackend val ~ Sql.SqlBackend) => [Sql.Filter val] -> DatabaseDiscord d Int64
+deleteWhereCount :: (Sql.PersistEntity val, Sql.PersistEntityBackend val ~ Sql.SqlBackend) => [Sql.Filter val] -> EnvDatabaseDiscord d Int64
 deleteWhereCount r = liftSql $ Sql.deleteWhereCount r
 
-update :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Key record -> [Sql.Update record] -> DatabaseDiscord d ()
+update :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Key record -> [Sql.Update record] -> EnvDatabaseDiscord d ()
 update r v = liftSql $ Sql.update r v
 
-updateWhere :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> [Sql.Update record] -> DatabaseDiscord d ()
+updateWhere :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> [Sql.Update record] -> EnvDatabaseDiscord d ()
 updateWhere r v = liftSql $ Sql.updateWhere r v
 
-updateWhereCount :: (Sql.PersistEntity val, Sql.PersistEntityBackend val ~ Sql.SqlBackend) => [Sql.Filter val] -> [Sql.Update val] -> DatabaseDiscord d Int64
+updateWhereCount :: (Sql.PersistEntity val, Sql.PersistEntityBackend val ~ Sql.SqlBackend) => [Sql.Filter val] -> [Sql.Update val] -> EnvDatabaseDiscord d Int64
 updateWhereCount r v = liftSql $ Sql.updateWhereCount r v
 
-updateGet :: (Sql.PersistEntity a, Sql.PersistEntityBackend a ~ Sql.SqlBackend) => Sql.Key a -> [Sql.Update a] -> DatabaseDiscord d a
+updateGet :: (Sql.PersistEntity a, Sql.PersistEntityBackend a ~ Sql.SqlBackend) => Sql.Key a -> [Sql.Update a] -> EnvDatabaseDiscord d a
 updateGet r v = liftSql $ Sql.updateGet r v
 
-upsert :: (Sql.OnlyOneUniqueKey record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> [Sql.Update record] -> DatabaseDiscord d (Sql.Entity record)
+upsert :: (Sql.OnlyOneUniqueKey record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> [Sql.Update record] -> EnvDatabaseDiscord d (Sql.Entity record)
 upsert r v = liftSql $ Sql.upsert r v
 
-count :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> DatabaseDiscord d Int
+count :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> EnvDatabaseDiscord d Int
 count r = liftSql $ Sql.count r
 
-exists :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> DatabaseDiscord d Bool
+exists :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> EnvDatabaseDiscord d Bool
 exists r = liftSql $ Sql.exists r
 
-selectFirst :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> [Sql.SelectOpt record] -> DatabaseDiscord d (Maybe (Sql.Entity record))
+selectFirst :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> [Sql.SelectOpt record] -> EnvDatabaseDiscord d (Maybe (Sql.Entity record))
 selectFirst r v = liftSql $ Sql.selectFirst r v
 
-selectKeysList :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> [Sql.SelectOpt record] -> DatabaseDiscord d [Sql.Key record]
+selectKeysList :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> [Sql.SelectOpt record] -> EnvDatabaseDiscord d [Sql.Key record]
 selectKeysList r v = liftSql $ Sql.selectKeysList r v
 
-selectList :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> [Sql.SelectOpt record] -> DatabaseDiscord d [Sql.Entity record]
+selectList :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> [Sql.SelectOpt record] -> EnvDatabaseDiscord d [Sql.Entity record]
 selectList r v = liftSql $ Sql.selectList r v
 
-get :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Key record -> DatabaseDiscord d (Maybe record)
+get :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Key record -> EnvDatabaseDiscord d (Maybe record)
 get v = liftSql $ Sql.get v
 
-getBy :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Unique record -> DatabaseDiscord d (Maybe (Sql.Entity record))
+getBy :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Unique record -> EnvDatabaseDiscord d (Maybe (Sql.Entity record))
 getBy v = liftSql $ Sql.getBy v
 
-getByValue :: (Sql.AtLeastOneUniqueKey record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> DatabaseDiscord d (Maybe (Sql.Entity record))
+getByValue :: (Sql.AtLeastOneUniqueKey record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => record -> EnvDatabaseDiscord d (Maybe (Sql.Entity record))
 getByValue v = liftSql $ Sql.getByValue v
 
-getEntity :: (Sql.PersistEntity e, Sql.PersistEntityBackend e ~ Sql.SqlBackend) => Sql.Key e -> DatabaseDiscord d (Maybe (Sql.Entity e))
+getEntity :: (Sql.PersistEntity e, Sql.PersistEntityBackend e ~ Sql.SqlBackend) => Sql.Key e -> EnvDatabaseDiscord d (Maybe (Sql.Entity e))
 getEntity v = liftSql $ Sql.getEntity v
 
-getFieldName :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.EntityField record typ -> DatabaseDiscord d Text
+getFieldName :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.EntityField record typ -> EnvDatabaseDiscord d Text
 getFieldName v = liftSql $ Sql.getFieldName v
 
-getJust :: (Sql.PersistEntity a, Sql.PersistEntityBackend a ~ Sql.SqlBackend) => Sql.Key a -> DatabaseDiscord d a
+getJust :: (Sql.PersistEntity a, Sql.PersistEntityBackend a ~ Sql.SqlBackend) => Sql.Key a -> EnvDatabaseDiscord d a
 getJust v = liftSql $ Sql.getJust v
 
-getJustEntity :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Key record -> DatabaseDiscord d (Sql.Entity record)
+getJustEntity :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => Sql.Key record -> EnvDatabaseDiscord d (Sql.Entity record)
 getJustEntity v = liftSql $ Sql.getJustEntity v
 
-getMany :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Key record] -> DatabaseDiscord d (Map (Sql.Key record) record)
+getMany :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Key record] -> EnvDatabaseDiscord d (Map (Sql.Key record) record)
 getMany v = liftSql $ Sql.getMany v

--- a/src/Tablebot/Plugin/Database.hs
+++ b/src/Tablebot/Plugin/Database.hs
@@ -69,6 +69,9 @@ upsert r v = liftSql $ Sql.upsert r v
 count :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> DatabaseDiscord d Int
 count r = liftSql $ Sql.count r
 
+exists :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> DatabaseDiscord d Bool
+exists r = liftSql $ Sql.exists r
+
 selectFirst :: (Sql.PersistEntity record, Sql.PersistEntityBackend record ~ Sql.SqlBackend) => [Sql.Filter record] -> [Sql.SelectOpt record] -> DatabaseDiscord d (Maybe (Sql.Entity record))
 selectFirst r v = liftSql $ Sql.selectFirst r v
 

--- a/src/Tablebot/Plugin/Discord.hs
+++ b/src/Tablebot/Plugin/Discord.hs
@@ -24,7 +24,7 @@ import Discord (RestCallErrorCode, restCall)
 import qualified Discord.Requests as R
 import Discord.Types
 import Tablebot.Handler.Embed
-import Tablebot.Plugin (DatabaseDiscord, liftDiscord)
+import Tablebot.Plugin (EnvDatabaseDiscord, liftDiscord)
 import Tablebot.Plugin.Exception (BotException (..))
 
 -- | @sendMessage@ sends the input message @t@ in the same channel as message
@@ -33,7 +33,7 @@ import Tablebot.Plugin.Exception (BotException (..))
 sendMessage ::
   Message ->
   Text ->
-  DatabaseDiscord s ()
+  EnvDatabaseDiscord s ()
 sendMessage m t = do
   res <- liftDiscord . restCall $ R.CreateMessage (messageChannel m) t
   case res of
@@ -52,7 +52,7 @@ sendEmbedMessage ::
   Message ->
   Text ->
   e ->
-  DatabaseDiscord s ()
+  EnvDatabaseDiscord s ()
 sendEmbedMessage m t e = do
   res <- liftDiscord . restCall $ TablebotEmbedRequest (messageChannel m) t (asEmbed e)
   case res of
@@ -64,7 +64,7 @@ sendEmbedMessage m t e = do
 getMessage ::
   ChannelId ->
   MessageId ->
-  DatabaseDiscord s (Either RestCallErrorCode Message)
+  EnvDatabaseDiscord s (Either RestCallErrorCode Message)
 getMessage cid mid = liftDiscord . restCall $ R.GetChannelMessage (cid, mid)
 
 -- | @reactToMessage@ reacts to the given message with the emoji specified
@@ -73,20 +73,20 @@ getMessage cid mid = liftDiscord . restCall $ R.GetChannelMessage (cid, mid)
 reactToMessage ::
   Message ->
   Text ->
-  DatabaseDiscord s (Either RestCallErrorCode ())
+  EnvDatabaseDiscord s (Either RestCallErrorCode ())
 reactToMessage m e =
   liftDiscord . restCall $
     R.CreateReaction (messageChannel m, messageId m) e
 
 -- | @getMessageMember@ returns the message member object if it was sent from a Discord server,
 -- or @Nothing@ if it was sent from a DM (or the API fails)
-getMessageMember :: Message -> DatabaseDiscord s (Maybe GuildMember)
+getMessageMember :: Message -> EnvDatabaseDiscord s (Maybe GuildMember)
 getMessageMember m = gMM (messageGuild m) m
   where
     maybeRight :: Either a b -> Maybe b
     maybeRight (Left _) = Nothing
     maybeRight (Right a) = Just a
-    gMM :: Maybe GuildId -> Message -> DatabaseDiscord s (Maybe GuildMember)
+    gMM :: Maybe GuildId -> Message -> EnvDatabaseDiscord s (Maybe GuildMember)
     gMM Nothing _ = return Nothing
     gMM (Just g') m' = do
       a <- liftDiscord $ restCall $ R.GetGuildMember g' (userId $ messageAuthor m')

--- a/src/Tablebot/Plugin/Exception.hs
+++ b/src/Tablebot/Plugin/Exception.hs
@@ -62,8 +62,8 @@ errorEmoji = ":warning:"
 -- | @formatUserError@ takes an error's name and message and makes it pretty for
 -- Discord.
 formatUserError :: String -> String -> String
-formatUserError name message =
-  errorEmoji ++ " **" ++ name ++ "** " ++ errorEmoji ++ "\n"
+formatUserError name' message =
+  errorEmoji ++ " **" ++ name' ++ "** " ++ errorEmoji ++ "\n"
     ++ "An error was encountered while resolving your command:\n"
     ++ "> `"
     ++ message
@@ -102,11 +102,11 @@ errorInfo :: BotException -> ErrorInfo
 
 -- | Add new errors here. Do not modify anything above this line except to
 -- declare new errors in the definition of BotException.
-errorInfo (GenericException name msg) = ErrorInfo name msg
-errorInfo (MessageSendException msg) = ErrorInfo "MessageSendException" msg
-errorInfo (ParserException msg) = ErrorInfo "ParserException" msg
+errorInfo (GenericException name' msg') = ErrorInfo name' msg'
+errorInfo (MessageSendException msg') = ErrorInfo "MessageSendException" msg'
+errorInfo (ParserException msg') = ErrorInfo "ParserException" msg'
 errorInfo (IndexOutOfBoundsException index (a, b)) =
   ErrorInfo
     "IndexOutOfBoundsException"
     $ "Index value of " ++ show index ++ " is not in the valid range [" ++ show a ++ ", " ++ show b ++ "]."
-errorInfo (RandomException msg) = ErrorInfo "RandomException" msg
+errorInfo (RandomException msg') = ErrorInfo "RandomException" msg'

--- a/src/Tablebot/Plugin/Help.hs
+++ b/src/Tablebot/Plugin/Help.hs
@@ -13,10 +13,12 @@ import Data.Functor (($>))
 import Data.Text (Text)
 import qualified Data.Text as T
 import Tablebot.Handler.Permission (getSenderPermission, userHasPermission)
+import Tablebot.Handler.Plugins (changeAction)
+import Tablebot.Handler.Types
 import Tablebot.Plugin.Discord (Message, sendMessage)
 import Tablebot.Plugin.Parser (skipSpace)
 import Tablebot.Plugin.Permission (requirePermission)
-import Tablebot.Plugin.Types
+import Tablebot.Plugin.Types hiding (helpPages)
 import Text.Megaparsec (choice, chunk, eof, try, (<?>), (<|>))
 
 rootBody :: Text
@@ -28,25 +30,25 @@ rootBody =
 helpHelpPage :: HelpPage
 helpHelpPage = HelpPage "help" "show information about commands" "**Help**\nShows information about bot commands\n\n*Usage:* `help <page>`" [] None
 
-generateHelp :: Plugin -> Plugin
+generateHelp :: CombinedPlugin -> CombinedPlugin
 generateHelp p =
   p
-    { commands = Command "help" (handleHelp (helpHelpPage : helpPages p)) : commands p
+    { combinedSetupAction = return (PA [CCommand "help" (handleHelp (helpHelpPage : combinedHelpPages p))] [] [] [] [] [] []) : combinedSetupAction p
     }
 
-handleHelp :: [HelpPage] -> Parser (Message -> DatabaseDiscord ())
+handleHelp :: [HelpPage] -> Parser (Message -> CompiledDatabaseDiscord ())
 handleHelp hp = parseHelpPage root
   where
     root = HelpPage "" "" rootBody hp None
 
-parseHelpPage :: HelpPage -> Parser (Message -> DatabaseDiscord ())
+parseHelpPage :: HelpPage -> Parser (Message -> CompiledDatabaseDiscord ())
 parseHelpPage hp = do
   _ <- chunk (helpName hp)
   skipSpace
   (try eof $> displayHelp hp) <|> choice (map parseHelpPage $ helpSubpages hp) <?> "Unknown Subcommand"
 
-displayHelp :: HelpPage -> Message -> DatabaseDiscord ()
-displayHelp hp m = requirePermission (helpPermission hp) m $ do
+displayHelp :: HelpPage -> Message -> CompiledDatabaseDiscord ()
+displayHelp hp m = changeAction () . requirePermission (helpPermission hp) m $ do
   uPerm <- getSenderPermission m
   sendMessage m $ formatHelp uPerm hp
 

--- a/src/Tablebot/Plugin/Permission.hs
+++ b/src/Tablebot/Plugin/Permission.hs
@@ -16,7 +16,7 @@ import Tablebot.Plugin.Discord (sendMessage)
 import Tablebot.Plugin.Types
 
 -- | @requirePermission@ only runs the inputted effect if permissions are matched. Otherwise it returns an error.
-requirePermission :: RequiredPermission -> Message -> DatabaseDiscord () -> DatabaseDiscord ()
+requirePermission :: RequiredPermission -> Message -> DatabaseDiscord s () -> DatabaseDiscord s ()
 requirePermission perm m a = do
   p <- getSenderPermission m
   if userHasPermission perm p

--- a/src/Tablebot/Plugin/Permission.hs
+++ b/src/Tablebot/Plugin/Permission.hs
@@ -16,7 +16,7 @@ import Tablebot.Plugin.Discord (sendMessage)
 import Tablebot.Plugin.Types
 
 -- | @requirePermission@ only runs the inputted effect if permissions are matched. Otherwise it returns an error.
-requirePermission :: RequiredPermission -> Message -> DatabaseDiscord s () -> DatabaseDiscord s ()
+requirePermission :: RequiredPermission -> Message -> EnvDatabaseDiscord s () -> EnvDatabaseDiscord s ()
 requirePermission perm m a = do
   p <- getSenderPermission m
   if userHasPermission perm p

--- a/src/Tablebot/Plugin/SmartCommand.hs
+++ b/src/Tablebot/Plugin/SmartCommand.hs
@@ -24,26 +24,26 @@ import Text.Megaparsec
 
 -- | @PComm@ defines function types that we can automatically turn into parsers
 -- by composing a parser per input of the function provided.
--- For example, @Int -> Maybe Text -> Message -> DatabaseDiscord ()@ builds a
+-- For example, @Int -> Maybe Text -> Message -> DatabaseDiscord s ()@ builds a
 -- parser that reads in an @Int@, then some optional @Text@, and then uses
 -- those to run the provided function with the arguments parsed and the message
 -- itself.
-class PComm commandty where
-  parseComm :: commandty -> Parser (Message -> DatabaseDiscord ())
+class PComm commandty s where
+  parseComm :: commandty -> Parser (Message -> DatabaseDiscord s ())
 
 -- As a base case, remove the spacing and check for eof.
-instance {-# OVERLAPPING #-} PComm (Message -> DatabaseDiscord ()) where
+instance {-# OVERLAPPING #-} PComm (Message -> DatabaseDiscord s ()) s where
   parseComm comm = skipSpace >> eof >> return comm
 
 -- Second base case is the single argument - no trailing space is wanted so we
 -- have to specify this case.
-instance {-# OVERLAPPING #-} CanParse a => PComm (a -> Message -> DatabaseDiscord ()) where
+instance {-# OVERLAPPING #-} CanParse a => PComm (a -> Message -> DatabaseDiscord s ()) s where
   parseComm comm = do
     this <- pars @a
     parseComm (comm this)
 
 -- Recursive case is to parse the domain of the function type, then the rest.
-instance {-# OVERLAPPABLE #-} (CanParse a, PComm as) => PComm (a -> as) where
+instance {-# OVERLAPPABLE #-} (CanParse a, PComm as s) => PComm (a -> as) s where
   parseComm comm = do
     this <- pars @a
     space
@@ -152,5 +152,5 @@ instance FromString a => CanParse (RestOfInput a) where
 
 -- | @noArguments@ is a type-specific alias for @parseComm@ for commands that
 -- have no arguments (thus making it extremely clear).
-noArguments :: (Message -> DatabaseDiscord ()) -> Parser (Message -> DatabaseDiscord ())
+noArguments :: (Message -> DatabaseDiscord d ()) -> Parser (Message -> DatabaseDiscord d ())
 noArguments = parseComm

--- a/src/Tablebot/Plugin/SmartCommand.hs
+++ b/src/Tablebot/Plugin/SmartCommand.hs
@@ -19,7 +19,7 @@ import Data.Text (Text, pack)
 import Discord.Types (Message)
 import GHC.TypeLits
 import Tablebot.Plugin.Parser
-import Tablebot.Plugin.Types (DatabaseDiscord, Parser)
+import Tablebot.Plugin.Types (DatabaseDiscord, EnvDatabaseDiscord, Parser)
 import Text.Megaparsec
 
 -- | @PComm@ defines function types that we can automatically turn into parsers
@@ -29,15 +29,15 @@ import Text.Megaparsec
 -- those to run the provided function with the arguments parsed and the message
 -- itself.
 class PComm commandty s where
-  parseComm :: commandty -> Parser (Message -> DatabaseDiscord s ())
+  parseComm :: commandty -> Parser (Message -> EnvDatabaseDiscord s ())
 
 -- As a base case, remove the spacing and check for eof.
-instance {-# OVERLAPPING #-} PComm (Message -> DatabaseDiscord s ()) s where
+instance {-# OVERLAPPING #-} PComm (Message -> EnvDatabaseDiscord s ()) s where
   parseComm comm = skipSpace >> eof >> return comm
 
 -- Second base case is the single argument - no trailing space is wanted so we
 -- have to specify this case.
-instance {-# OVERLAPPING #-} CanParse a => PComm (a -> Message -> DatabaseDiscord s ()) s where
+instance {-# OVERLAPPING #-} CanParse a => PComm (a -> Message -> EnvDatabaseDiscord s ()) s where
   parseComm comm = do
     this <- pars @a
     parseComm (comm this)
@@ -152,5 +152,5 @@ instance FromString a => CanParse (RestOfInput a) where
 
 -- | @noArguments@ is a type-specific alias for @parseComm@ for commands that
 -- have no arguments (thus making it extremely clear).
-noArguments :: (Message -> DatabaseDiscord d ()) -> Parser (Message -> DatabaseDiscord d ())
+noArguments :: (Message -> EnvDatabaseDiscord d ()) -> Parser (Message -> EnvDatabaseDiscord d ())
 noArguments = parseComm

--- a/src/Tablebot/Plugin/Types.hs
+++ b/src/Tablebot/Plugin/Types.hs
@@ -200,7 +200,8 @@ data RequiredPermission = None | Any | Exec | Moderator | Both | Superuser deriv
 -- | A plugin. Directly constructing these should be avoided (hence why it is
 -- not exported by "Tablebot.Plugin") as this structure could change.
 data Plugin = Pl
-  { commands :: [Command],
+  { pluginName :: Text,
+    commands :: [Command],
     inlineCommands :: [InlineCommand],
     onMessageChanges :: [MessageChange],
     onReactionAdds :: [ReactionAdd],
@@ -217,18 +218,19 @@ data Plugin = Pl
 --
 -- Examples of this in use can be found in the imports of
 -- "Tablebot.Plugins".
-plug :: Plugin
-plug = Pl [] [] [] [] [] [] [] [] []
+plug :: Text -> Plugin
+plug name' = Pl name' [] [] [] [] [] [] [] [] []
 
 -- | Combines a list of plugins into a single plugin with the combined
 -- functionality. The bot actually runs a single plugin, which is just the
 -- combined version of all input plugins.
 combinePlugins :: [Plugin] -> Plugin
-combinePlugins [] = plug
+combinePlugins [] = plug "_root"
 combinePlugins (p : ps) =
   let p' = combinePlugins ps
    in Pl
-        { commands = merge commands p p',
+        { pluginName = "_root",
+          commands = merge commands p p',
           inlineCommands = merge inlineCommands p p',
           onMessageChanges = merge onMessageChanges p p',
           onReactionAdds = merge onReactionAdds p p',

--- a/src/Tablebot/Plugin/Types.hs
+++ b/src/Tablebot/Plugin/Types.hs
@@ -12,7 +12,6 @@
 -- database and Discord operations within your features.
 module Tablebot.Plugin.Types where
 
-import Control.Monad (void)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Reader (ReaderT)
 import Data.Text (Text)

--- a/src/Tablebot/Plugins.hs
+++ b/src/Tablebot/Plugins.hs
@@ -15,7 +15,7 @@ module Tablebot.Plugins
 where
 
 import Tablebot.Plugin (Plugin)
-import Tablebot.Plugins.Administration (restartPlugin)
+import Tablebot.Plugins.Administration (administrationPlugin)
 import Tablebot.Plugins.Basic (basicPlugin)
 import Tablebot.Plugins.Cats (catPlugin)
 import Tablebot.Plugins.Flip (flipPlugin)
@@ -29,12 +29,12 @@ import Tablebot.Plugins.Welcome (welcomePlugin)
 plugins :: [Plugin]
 plugins =
   [ pingPlugin,
+    administrationPlugin,
     basicPlugin,
     catPlugin,
     flipPlugin,
     quotePlugin,
     reminderPlugin,
-    restartPlugin,
     sayPlugin,
     welcomePlugin
   ]

--- a/src/Tablebot/Plugins.hs
+++ b/src/Tablebot/Plugins.hs
@@ -16,7 +16,6 @@ where
 
 import Tablebot.Handler.Plugins (compilePlugin)
 import Tablebot.Handler.Types (CompiledPlugin)
-import Tablebot.Plugin (Plugin)
 import Tablebot.Plugins.Administration (administrationPlugin)
 import Tablebot.Plugins.Basic (basicPlugin)
 import Tablebot.Plugins.Cats (catPlugin)
@@ -30,13 +29,17 @@ import Tablebot.Plugins.Welcome (welcomePlugin)
 -- Use long list format to make additions and removals non-conflicting on git PRs
 plugins :: [CompiledPlugin]
 plugins =
-  [ compilePlugin pingPlugin,
-    compilePlugin administrationPlugin,
-    compilePlugin basicPlugin,
-    compilePlugin catPlugin,
-    compilePlugin flipPlugin,
-    compilePlugin quotePlugin,
-    compilePlugin reminderPlugin,
-    compilePlugin sayPlugin,
-    compilePlugin welcomePlugin
-  ]
+  addAdministrationPlugin
+    [ compilePlugin pingPlugin,
+      compilePlugin basicPlugin,
+      compilePlugin catPlugin,
+      compilePlugin flipPlugin,
+      compilePlugin quotePlugin,
+      compilePlugin reminderPlugin,
+      compilePlugin sayPlugin,
+      compilePlugin welcomePlugin
+    ]
+
+-- | @addAdministrationPlugin@ is needed to allow the administration plugin to be aware of the list of current plugins
+addAdministrationPlugin :: [CompiledPlugin] -> [CompiledPlugin]
+addAdministrationPlugin cps = compilePlugin (administrationPlugin cps) : cps

--- a/src/Tablebot/Plugins.hs
+++ b/src/Tablebot/Plugins.hs
@@ -14,6 +14,8 @@ module Tablebot.Plugins
   )
 where
 
+import Tablebot.Handler.Plugins (compilePlugin)
+import Tablebot.Handler.Types (CompiledPlugin)
 import Tablebot.Plugin (Plugin)
 import Tablebot.Plugins.Administration (administrationPlugin)
 import Tablebot.Plugins.Basic (basicPlugin)
@@ -26,15 +28,15 @@ import Tablebot.Plugins.Say (sayPlugin)
 import Tablebot.Plugins.Welcome (welcomePlugin)
 
 -- Use long list format to make additions and removals non-conflicting on git PRs
-plugins :: [Plugin]
+plugins :: [CompiledPlugin]
 plugins =
-  [ pingPlugin,
-    administrationPlugin,
-    basicPlugin,
-    catPlugin,
-    flipPlugin,
-    quotePlugin,
-    reminderPlugin,
-    sayPlugin,
-    welcomePlugin
+  [ compilePlugin pingPlugin,
+    compilePlugin administrationPlugin,
+    compilePlugin basicPlugin,
+    compilePlugin catPlugin,
+    compilePlugin flipPlugin,
+    compilePlugin quotePlugin,
+    compilePlugin reminderPlugin,
+    compilePlugin sayPlugin,
+    compilePlugin welcomePlugin
   ]

--- a/src/Tablebot/Plugins.hs
+++ b/src/Tablebot/Plugins.hs
@@ -15,6 +15,7 @@ module Tablebot.Plugins
 where
 
 import Tablebot.Plugin (Plugin)
+import Tablebot.Plugins.Administration (restartPlugin)
 import Tablebot.Plugins.Basic (basicPlugin)
 import Tablebot.Plugins.Cats (catPlugin)
 import Tablebot.Plugins.Flip (flipPlugin)
@@ -33,6 +34,7 @@ plugins =
     flipPlugin,
     quotePlugin,
     reminderPlugin,
+    restartPlugin,
     sayPlugin,
     welcomePlugin
   ]

--- a/src/Tablebot/Plugins/Administration.hs
+++ b/src/Tablebot/Plugins/Administration.hs
@@ -1,0 +1,48 @@
+-- |
+-- Module      : Tablebot.Plugins.Say
+-- Description : A command that outputs its input.
+-- Copyright   : (c) Amelie WD 2021
+-- License     : MIT
+-- Maintainer  : tablebot@ameliewd.com
+-- Stability   : experimental
+-- Portability : POSIX
+--
+-- Commands that
+module Tablebot.Plugins.Administration (restartPlugin) where
+
+import Control.Monad.Trans.Class (MonadTrans (lift))
+import Data.Text (Text, pack)
+import Discord (stopDiscord)
+import Discord.Types
+import Tablebot.Plugin
+import Tablebot.Plugin.Discord (Message, sendMessage)
+import Tablebot.Plugin.Parser (untilEnd)
+import Text.Megaparsec
+import Text.RawString.QQ
+
+-- | @restart@ reloads the bot with any new configuration changes.
+restart :: Command
+restart = Command "restart" saycomm
+  where
+    saycomm :: Parser (Message -> DatabaseDiscord ())
+    saycomm = do
+      input <- untilEnd
+      return $ \m -> do
+        sendMessage m "Restarting"
+        lift $ stopDiscord
+
+restartHelp :: HelpPage
+restartHelp =
+  HelpPage
+    "restart"
+    "restart the bot"
+    [r|**Restart**
+Restart the bot
+
+*Usage:* `reastart`|]
+    []
+    None
+
+-- | @restartPlugin@ assembles the command into a plugin.
+restartPlugin :: Plugin
+restartPlugin = (plug "restart") {commands = [restart], helpPages = [restartHelp]}

--- a/src/Tablebot/Plugins/Administration.hs
+++ b/src/Tablebot/Plugins/Administration.hs
@@ -91,8 +91,8 @@ listBlacklist m = requirePermission Superuser m $ do
 %Q
 ```
 %Q|]
-        (T.concat $ map (formatPluginState len' bl) (filter (disableable . T.uncons) p))
-        (formatUnknownDisabledPlugins (filter (`notElem` p) bl))
+          (T.concat $ map (formatPluginState len' bl) (filter (disableable . T.uncons) p))
+          (formatUnknownDisabledPlugins (filter (`notElem` p) bl))
       where
         len' :: Int
         len' = maximum $ map T.length p
@@ -107,8 +107,8 @@ listBlacklist m = requirePermission Superuser m $ do
       pack $
         [s|%Q : %Q
 |]
-        (T.justifyLeft width ' ' a)
-        (if a `elem` bl then "DISABLED" else "ENABLED")
+          (T.justifyLeft width ' ' a)
+          (if a `elem` bl then "DISABLED" else "ENABLED")
     formatUnknownDisabledPlugins :: [Text] -> Text
     formatUnknownDisabledPlugins [] = ""
     formatUnknownDisabledPlugins l =
@@ -117,7 +117,7 @@ listBlacklist m = requirePermission Superuser m $ do
 ```
 %Q
 ```|]
-        (T.concat $ map (<> ("\n" :: Text)) l)
+          (T.concat $ map (<> ("\n" :: Text)) l)
 
 -- | @restart@ reloads the bot with any new configuration changes.
 reload :: EnvCommand SS

--- a/src/Tablebot/Plugins/Administration.hs
+++ b/src/Tablebot/Plugins/Administration.hs
@@ -1,48 +1,152 @@
 -- |
--- Module      : Tablebot.Plugins.Say
+-- Module      : Tablebot.Plugins.Administration
 -- Description : A command that outputs its input.
--- Copyright   : (c) Amelie WD 2021
+-- Copyright   : (c) Anna Bruce 2021
 -- License     : MIT
 -- Maintainer  : tablebot@ameliewd.com
 -- Stability   : experimental
 -- Portability : POSIX
 --
--- Commands that
-module Tablebot.Plugins.Administration (restartPlugin) where
+-- Commands that manage the loading and reloading of plugins
+module Tablebot.Plugins.Administration (administrationPlugin) where
 
 import Control.Monad.Trans.Class (MonadTrans (lift))
 import Data.Text (Text, pack)
+import qualified Data.Text as T
+import Database.Persist (Entity, Filter, delete, entityVal, exists, insert, selectKeysList, selectList, (==.))
+import Database.Persist.TH
 import Discord (stopDiscord)
 import Discord.Types
+-- import from handler is unorthodox, but I don't want other plugins messing with that table...
+import Tablebot.Handler.Administration
 import Tablebot.Plugin
-import Tablebot.Plugin.Discord (Message, sendMessage)
-import Tablebot.Plugin.Parser (untilEnd)
-import Text.Megaparsec
+import Tablebot.Plugin.Discord (sendMessage)
+import Tablebot.Plugin.Parser (word)
+import Tablebot.Plugin.Permission (requirePermission)
+import Tablebot.Plugin.SmartCommand
+import Text.Megaparsec (chunk, (<?>), (<|>))
 import Text.RawString.QQ
 
--- | @restart@ reloads the bot with any new configuration changes.
-restart :: Command
-restart = Command "restart" saycomm
-  where
-    saycomm :: Parser (Message -> DatabaseDiscord ())
-    saycomm = do
-      input <- untilEnd
-      return $ \m -> do
-        sendMessage m "Restarting"
-        lift $ stopDiscord
+blacklist :: Command
+blacklist = Command "blacklist" (parseComm blacklistComm)
 
-restartHelp :: HelpPage
-restartHelp =
+blacklistComm ::
+  WithError
+    "Unknown quote functionality."
+    ( Either
+        ( Either
+            (Exactly "add", String)
+            (Exactly "remove", String)
+        )
+        (Exactly "list")
+    ) ->
+  Message ->
+  DatabaseDiscord ()
+blacklistComm (WErr (Left (Left (_, pLabel)))) = addBlacklist pLabel
+blacklistComm (WErr (Left (Right (_, pLabel)))) = removeBlacklist pLabel
+blacklistComm (WErr (Right (_))) = listBlacklist
+
+addBlacklist :: String -> Message -> DatabaseDiscord ()
+addBlacklist pLabel m = requirePermission Superuser m $ do
+  extant <- exists [PluginBlacklistLabel ==. pLabel]
+  if not $ extant
+    then do
+      _ <- insert $ PluginBlacklist pLabel
+      sendMessage m "Plugin added to blacklist. Please reload for it to take effect"
+    else sendMessage m "Plugin already in blacklist"
+
+removeBlacklist :: String -> Message -> DatabaseDiscord ()
+removeBlacklist pLabel m = requirePermission Superuser m $ do
+  extant <- selectKeysList [PluginBlacklistLabel ==. pLabel] []
+  if not $ null extant
+    then do
+      _ <- delete (head extant)
+      sendMessage m "Plugin removed from blacklist. Please reload for it to take effect"
+    else sendMessage m "Plugin not in blacklist"
+
+-- | @listBlacklist@ shows the plugin names in the blacklist.
+listBlacklist :: Message -> DatabaseDiscord ()
+listBlacklist m = requirePermission Superuser m $ do
+  bl <- selectList allBlacklisted []
+  sendMessage m (format $ bl)
+  where
+    allBlacklisted :: [Filter PluginBlacklist]
+    allBlacklisted = []
+    format :: [Entity PluginBlacklist] -> Text
+    format a = "**Blacklisted Plugins:**\n" <> (T.concat $ map format' a)
+    format' :: Entity PluginBlacklist -> Text
+    format' a = (pack $ pluginBlacklistLabel $ entityVal a) <> "\n"
+
+-- | @restart@ reloads the bot with any new configuration changes.
+reload :: Command
+reload = Command "reload" restartCommand
+  where
+    restartCommand :: Parser (Message -> DatabaseDiscord ())
+    restartCommand = noArguments $ \m -> requirePermission Superuser m $ do
+      sendMessage m "Reloading bot..."
+      lift $ stopDiscord
+
+reloadHelp :: HelpPage
+reloadHelp =
   HelpPage
-    "restart"
-    "restart the bot"
+    "reload"
+    "reload the bot"
     [r|**Restart**
 Restart the bot
 
-*Usage:* `reastart`|]
+*Usage:* `reload`|]
     []
-    None
+    Superuser
 
--- | @restartPlugin@ assembles the command into a plugin.
-restartPlugin :: Plugin
-restartPlugin = (plug "restart") {commands = [restart], helpPages = [restartHelp]}
+blacklistAddHelp :: HelpPage
+blacklistAddHelp =
+  HelpPage
+    "add"
+    "Disable a plugin"
+    "**Blacklist Add**\n\
+    \Disable a plugin. This does **not** check that the entered plugin is currently avaliable. \
+    \This allows you to upgrade without having a new plugin enabled breifly.\n\n\
+    \*Usage*: `blacklist add <plugin>`"
+    []
+    Superuser
+
+blacklistRemoveHelp :: HelpPage
+blacklistRemoveHelp =
+  HelpPage
+    "remove"
+    "Enable a plugin"
+    [r|**Blacklist Remove**
+Re-enable a plugin.
+
+*Usage*: `blacklist remove <plugin>`
+|]
+    []
+    Superuser
+
+blacklistListHelp :: HelpPage
+blacklistListHelp =
+  HelpPage
+    "list"
+    "List disabled plugins"
+    [r|**Blacklist List**
+List the current plugins in the blacklist.
+
+*Usage*: `blacklist list`
+|]
+    []
+    Superuser
+
+blacklistHelp :: HelpPage
+blacklistHelp =
+  HelpPage
+    "blacklist"
+    "Enable and disable plugins"
+    [r|**Blacklist**
+Enable and disable plugins|]
+    [blacklistListHelp, blacklistAddHelp, blacklistRemoveHelp]
+    Superuser
+
+-- | @administrationPlugin@ assembles the commands into a plugin.
+-- Note the use of an underscore in the name, this prevents the plugin being disabled.
+administrationPlugin :: Plugin
+administrationPlugin = (plug "_admin") {commands = [reload, blacklist], helpPages = [reloadHelp, blacklistHelp]}

--- a/src/Tablebot/Plugins/Administration.hs
+++ b/src/Tablebot/Plugins/Administration.hs
@@ -1,9 +1,8 @@
 -- |
 -- Module      : Tablebot.Plugins.Administration
--- Description : A command that outputs its input.
--- Copyright   : (c) Anna Bruce 2021
+-- Description : A set of commands that allows an administrator to manage the whole bot.
 -- License     : MIT
--- Maintainer  : tablebot@ameliewd.com
+-- Maintainer  : tagarople@gmail.com
 -- Stability   : experimental
 -- Portability : POSIX
 --

--- a/src/Tablebot/Plugins/Administration.hs
+++ b/src/Tablebot/Plugins/Administration.hs
@@ -57,7 +57,7 @@ addBlacklist pLabel m = requirePermission Superuser m $ do
   -- but emmit a warning so people know if it wasn't deliberate
   when ((pack pLabel) `notElem` known) $ sendMessage m "Warning, unknown plugin"
   extant <- exists [PluginBlacklistLabel ==. pLabel]
-  if not $ extant
+  if not extant
     then do
       _ <- insert $ PluginBlacklist pLabel
       sendMessage m "Plugin added to blacklist. Please reload for it to take effect"

--- a/src/Tablebot/Plugins/Administration.hs
+++ b/src/Tablebot/Plugins/Administration.hs
@@ -35,7 +35,7 @@ blacklist = Command "blacklist" (parseComm blacklistComm)
 
 blacklistComm ::
   WithError
-    "Unknown quote functionality."
+    "Unknown blacklist functionality."
     ( Either
         ( Either
             (Exactly "add", String)

--- a/src/Tablebot/Plugins/Basic.hs
+++ b/src/Tablebot/Plugins/Basic.hs
@@ -14,12 +14,18 @@ import Data.Text.Internal (Text)
 import Tablebot.Plugin (DatabaseDiscord)
 import Tablebot.Plugin.Discord (Message, sendMessage)
 import Tablebot.Plugin.SmartCommand (parseComm)
-import Tablebot.Plugin.Types (Command (Command), HelpPage (HelpPage), Plugin (commands), RequiredPermission (None), helpPages, plug)
+import Tablebot.Plugin.Types
+  ( Command,
+    EnvCommand (Command),
+    EnvPlugin (commands),
+    HelpPage (HelpPage),
+    Plugin,
+    RequiredPermission (None),
+    helpPages,
+    plug,
+  )
 
 -- * Some types to help clarify what's going on
-
--- | @SS@ denotes the type returned by the command setup. Here its unused.
-type SS = ()
 
 -- | @MiniHelpPage@ simplifies creating the help pages. You can either provide just the short and long help text and let
 -- it autogenerate the formatting, or you can provide a full help page if you want more control
@@ -45,11 +51,11 @@ basicCommands =
 
 -- | @echo@ pulled out to help resolve parser overlapping instances errors.
 -- Sends the provided text, regardless of received message.
-echo :: Text -> Message -> DatabaseDiscord SS ()
+echo :: Text -> Message -> DatabaseDiscord ()
 echo t m = sendMessage m t
 
 -- | Given command text "a", reply with text "b".
-baseCommand :: BasicCommand -> Command SS
+baseCommand :: BasicCommand -> Command
 baseCommand (a, b, _) =
   Command
     a
@@ -60,7 +66,7 @@ baseHelp (_, _, Advanced help) = help
 baseHelp (a, _, Simple (short, long)) = HelpPage a short ("**" <> toTitle a <> "**\n" <> long <> "\n\n*Usage:* `" <> a <> "`") [] None
 
 -- | @basicPlugin@ assembles the call and response commands into a simple command list.
-basicPlugin :: Plugin SS
+basicPlugin :: Plugin
 basicPlugin =
   (plug "basic")
     { commands = map baseCommand basicCommands,

--- a/src/Tablebot/Plugins/Basic.hs
+++ b/src/Tablebot/Plugins/Basic.hs
@@ -56,7 +56,7 @@ baseHelp (a, _, Simple (short, long)) = HelpPage a short ("**" <> toTitle a <> "
 -- | @basicPlugin@ assembles the call and response commands into a simple command list.
 basicPlugin :: Plugin
 basicPlugin =
-  plug
+  (plug "basic")
     { commands = map baseCommand basicCommands,
       helpPages = map baseHelp basicCommands
     }

--- a/src/Tablebot/Plugins/Cats.hs
+++ b/src/Tablebot/Plugins/Cats.hs
@@ -76,4 +76,4 @@ catHelp = HelpPage "cat" "displays an image of a cat" "**Cat**\nGets a random ca
 
 -- | @catPlugin@ assembles these commands into a plugin containing cat
 catPlugin :: Plugin
-catPlugin = plug {commands = [cat], helpPages = [catHelp]}
+catPlugin = (plug "cats") {commands = [cat], helpPages = [catHelp]}

--- a/src/Tablebot/Plugins/Cats.hs
+++ b/src/Tablebot/Plugins/Cats.hs
@@ -20,7 +20,16 @@ import Network.HTTP.Simple (addRequestHeader, httpLBS)
 import System.Environment (lookupEnv)
 import Tablebot.Plugin.Discord (Message, sendMessage)
 import Tablebot.Plugin.SmartCommand (parseComm)
-import Tablebot.Plugin.Types (Command (Command), DatabaseDiscord, HelpPage (HelpPage), Plugin (..), RequiredPermission (None), plug)
+import Tablebot.Plugin.Types
+  ( Command,
+    DatabaseDiscord,
+    EnvCommand (Command),
+    EnvPlugin (..),
+    HelpPage (HelpPage),
+    Plugin,
+    RequiredPermission (None),
+    plug,
+  )
 
 -- | @CatAPI@ is the basic data type for the JSON object that thecatapi returns
 data CatAPI = CatAPI
@@ -34,18 +43,15 @@ data CatAPI = CatAPI
 
 instance FromJSON CatAPI
 
--- | @SS@ denotes the type returned by the command setup. Here its unused.
-type SS = ()
-
 -- | @cat@ is a command that takes no arguments (using 'noArguments') and
 -- replies with an image of a cat. Uses https://docs.thecatapi.com/ for cats.
-cat :: Command SS
+cat :: Command
 cat =
   Command
     "cat"
     (parseComm sendCat)
   where
-    sendCat :: Message -> DatabaseDiscord SS ()
+    sendCat :: Message -> DatabaseDiscord ()
     sendCat m = do
       r <- liftIO (getCatAPI <&> getCat)
       sendMessage m r
@@ -79,5 +85,5 @@ catHelp :: HelpPage
 catHelp = HelpPage "cat" "displays an image of a cat" "**Cat**\nGets a random cat image using <https://thecatapi.com/>.\n\n*Usage:* `cat`" [] None
 
 -- | @catPlugin@ assembles these commands into a plugin containing cat
-catPlugin :: Plugin SS
+catPlugin :: Plugin
 catPlugin = (plug "cats") {commands = [cat], helpPages = [catHelp]}

--- a/src/Tablebot/Plugins/Flip.hs
+++ b/src/Tablebot/Plugins/Flip.hs
@@ -49,4 +49,4 @@ Randomly picks one element from its arguments or, if none are provided, picks fr
 
 -- | @flipPlugin@ assembles the command into a plugin.
 flipPlugin :: Plugin
-flipPlugin = plug {commands = [flip], helpPages = [flipHelp]}
+flipPlugin = (plug "flip") {commands = [flip], helpPages = [flipHelp]}

--- a/src/Tablebot/Plugins/Flip.hs
+++ b/src/Tablebot/Plugins/Flip.hs
@@ -19,12 +19,15 @@ import Text.Megaparsec
 import Text.RawString.QQ
 import Prelude hiding (flip)
 
+-- | @SS@ denotes the type returned by the command setup. Here its unused.
+type SS = ()
+
 -- | @flip@ picks one of its arguments at random, or one of "heads" and "tails"
 -- if none are provided.
-flip :: Command
+flip :: Command SS
 flip = Command "flip" flipcomm
   where
-    flipcomm :: Parser (Message -> DatabaseDiscord ())
+    flipcomm :: Parser (Message -> DatabaseDiscord SS ())
     flipcomm = do
       args <- nonSpaceWord `sepBy` space
       return $ \m -> do
@@ -48,5 +51,5 @@ Randomly picks one element from its arguments or, if none are provided, picks fr
     None
 
 -- | @flipPlugin@ assembles the command into a plugin.
-flipPlugin :: Plugin
+flipPlugin :: Plugin SS
 flipPlugin = (plug "flip") {commands = [flip], helpPages = [flipHelp]}

--- a/src/Tablebot/Plugins/Flip.hs
+++ b/src/Tablebot/Plugins/Flip.hs
@@ -19,15 +19,12 @@ import Text.Megaparsec
 import Text.RawString.QQ
 import Prelude hiding (flip)
 
--- | @SS@ denotes the type returned by the command setup. Here its unused.
-type SS = ()
-
 -- | @flip@ picks one of its arguments at random, or one of "heads" and "tails"
 -- if none are provided.
-flip :: Command SS
+flip :: Command
 flip = Command "flip" flipcomm
   where
-    flipcomm :: Parser (Message -> DatabaseDiscord SS ())
+    flipcomm :: Parser (Message -> DatabaseDiscord ())
     flipcomm = do
       args <- nonSpaceWord `sepBy` space
       return $ \m -> do
@@ -51,5 +48,5 @@ Randomly picks one element from its arguments or, if none are provided, picks fr
     None
 
 -- | @flipPlugin@ assembles the command into a plugin.
-flipPlugin :: Plugin SS
+flipPlugin :: Plugin
 flipPlugin = (plug "flip") {commands = [flip], helpPages = [flipHelp]}

--- a/src/Tablebot/Plugins/Ping.hs
+++ b/src/Tablebot/Plugins/Ping.hs
@@ -14,17 +14,14 @@ import Tablebot.Plugin
 import Tablebot.Plugin.Discord (Message, sendMessage)
 import Tablebot.Plugin.SmartCommand (parseComm)
 
--- | @SS@ denotes the type returned by the command setup. Here its unused.
-type SS = ()
-
 -- | @echo@ pulled out to help resolve parser overlapping instances errors.
 -- Sends the provided text, regardless of received message.
-echo :: Text -> Message -> DatabaseDiscord SS ()
+echo :: Text -> Message -> DatabaseDiscord ()
 echo t m = sendMessage m t
 
 -- | @ping@ is a command that takes no arguments (using 'noArguments') and
 -- replies with "pong".
-ping :: Command SS
+ping :: Command
 ping =
   Command
     "ping"
@@ -33,7 +30,7 @@ ping =
 
 -- | @pong@ is a command that takes no arguments (using 'noArguments') and
 -- replies with "ping". It is the younger sibling of @ping@.
-pong :: Command SS
+pong :: Command
 pong =
   Command
     "pong"
@@ -48,5 +45,5 @@ pongHelp = HelpPage "pong" "show a more different debug message" "**Pong**\nShow
 
 -- | @pingPlugin@ assembles these commands into a plugin containing both ping
 -- and pong.
-pingPlugin :: Plugin SS
+pingPlugin :: Plugin
 pingPlugin = (plug "ping") {commands = [ping, pong], helpPages = [pingHelp, pongHelp]}

--- a/src/Tablebot/Plugins/Ping.hs
+++ b/src/Tablebot/Plugins/Ping.hs
@@ -44,4 +44,4 @@ pongHelp = HelpPage "pong" "show a more different debug message" "**Pong**\nShow
 -- | @pingPlugin@ assembles these commands into a plugin containing both ping
 -- and pong.
 pingPlugin :: Plugin
-pingPlugin = plug {commands = [ping, pong], helpPages = [pingHelp, pongHelp]}
+pingPlugin = (plug "ping") {commands = [ping, pong], helpPages = [pingHelp, pongHelp]}

--- a/src/Tablebot/Plugins/Ping.hs
+++ b/src/Tablebot/Plugins/Ping.hs
@@ -9,30 +9,35 @@
 -- This is an example plugin which just responds "ping" to "!pong" and vice-versa.
 module Tablebot.Plugins.Ping (pingPlugin) where
 
+import Data.Text (Text)
 import Tablebot.Plugin
-import Tablebot.Plugin.Discord (sendMessage)
+import Tablebot.Plugin.Discord (Message, sendMessage)
 import Tablebot.Plugin.SmartCommand (parseComm)
+
+-- | @SS@ denotes the type returned by the command setup. Here its unused.
+type SS = ()
+
+-- | @echo@ pulled out to help resolve parser overlapping instances errors.
+-- Sends the provided text, regardless of received message.
+echo :: Text -> Message -> DatabaseDiscord SS ()
+echo t m = sendMessage m t
 
 -- | @ping@ is a command that takes no arguments (using 'noArguments') and
 -- replies with "pong".
-ping :: Command
+ping :: Command SS
 ping =
   Command
     "ping"
-    ( parseComm $ \m -> do
-        _ <- sendMessage m "pong"
-        return ()
+    ( parseComm $ echo "pong"
     )
 
 -- | @pong@ is a command that takes no arguments (using 'noArguments') and
 -- replies with "ping". It is the younger sibling of @ping@.
-pong :: Command
+pong :: Command SS
 pong =
   Command
     "pong"
-    ( parseComm $ \m -> do
-        _ <- sendMessage m "ping"
-        return ()
+    ( parseComm $ echo "ping"
     )
 
 pingHelp :: HelpPage
@@ -43,5 +48,5 @@ pongHelp = HelpPage "pong" "show a more different debug message" "**Pong**\nShow
 
 -- | @pingPlugin@ assembles these commands into a plugin containing both ping
 -- and pong.
-pingPlugin :: Plugin
+pingPlugin :: Plugin SS
 pingPlugin = (plug "ping") {commands = [ping, pong], helpPages = [pingHelp, pongHelp]}

--- a/src/Tablebot/Plugins/Quote.hs
+++ b/src/Tablebot/Plugins/Quote.hs
@@ -34,11 +34,8 @@ Quote
     deriving Show
 |]
 
--- | @SS@ denotes the type returned by the command setup. Here its unused.
-type SS = ()
-
 -- | Our quote command, which combines @addQuote@ and @showQuote@.
-quote :: Command SS
+quote :: Command
 quote =
   Command
     "quote"
@@ -52,7 +49,7 @@ quoteComm ::
         (Either (Exactly "show", Int) (Exactly "delete", Int))
     ) ->
   Message ->
-  DatabaseDiscord SS ()
+  DatabaseDiscord ()
 quoteComm (WErr (Left (_, Qu qu, _, ROI author))) = addQ qu author
 quoteComm (WErr (Right (Left (_, qId)))) = showQ (fromIntegral qId)
 quoteComm (WErr (Right (Right (_, qId)))) = deleteQ (fromIntegral qId)
@@ -60,7 +57,7 @@ quoteComm (WErr (Right (Right (_, qId)))) = deleteQ (fromIntegral qId)
 -- | @addQuote@, which looks for a message of the form
 -- @!quote add "quoted text" - author@, and then stores said quote in the
 -- database, returning the ID used.
-addQ :: String -> String -> Message -> DatabaseDiscord SS ()
+addQ :: String -> String -> Message -> DatabaseDiscord ()
 addQ qu author m = do
   added <- insert $ Quote qu author
   let res = pack $ show $ fromSqlKey added
@@ -68,7 +65,7 @@ addQ qu author m = do
 
 -- | @showQuote@, which looks for a message of the form @!quote show n@, looks
 -- that quote up in the database and responds with that quote.
-showQ :: Int64 -> Message -> DatabaseDiscord SS ()
+showQ :: Int64 -> Message -> DatabaseDiscord ()
 showQ qId m = do
   qu <- get $ toSqlKey qId
   case qu of
@@ -78,7 +75,7 @@ showQ qId m = do
 
 -- | @deleteQuote@, which looks for a message of the form @!quote delete n@,
 -- and removes it from the database.
-deleteQ :: Int64 -> Message -> DatabaseDiscord SS ()
+deleteQ :: Int64 -> Message -> DatabaseDiscord ()
 deleteQ qId m =
   requirePermission Any m $
     let k = toSqlKey qId
@@ -114,5 +111,5 @@ quoteHelp = HelpPage "quote" "store and retrieve quotes" "**Quotes**\nAllows sto
 
 -- | @quotePlugin@ assembles the @quote@ command (consisting of @add@ and
 -- @show@) and the database migration into a plugin.
-quotePlugin :: Plugin SS
+quotePlugin :: Plugin
 quotePlugin = (plug "quote") {commands = [quote], migrations = [quoteMigration], helpPages = [quoteHelp]}

--- a/src/Tablebot/Plugins/Quote.hs
+++ b/src/Tablebot/Plugins/Quote.hs
@@ -113,4 +113,4 @@ quoteHelp = HelpPage "quote" "store and retrieve quotes" "**Quotes**\nAllows sto
 -- | @quotePlugin@ assembles the @quote@ command (consisting of @add@ and
 -- @show@) and the database migration into a plugin.
 quotePlugin :: Plugin
-quotePlugin = plug {commands = [quote], migrations = [quoteMigration], helpPages = [quoteHelp]}
+quotePlugin = (plug "quote") {commands = [quote], migrations = [quoteMigration], helpPages = [quoteHelp]}

--- a/src/Tablebot/Plugins/Reminder.hs
+++ b/src/Tablebot/Plugins/Reminder.hs
@@ -50,9 +50,6 @@ Reminder
     deriving Show
 |]
 
--- | @SS@ denotes the type returned by the command setup. Here its unused.
-type SS = ()
-
 -- Below duckling code was greatly helped by dixonary's example project, below
 -- <https://github.com/dixonary/duckling-example>
 
@@ -74,7 +71,7 @@ ducklingDateTime now rawString = do
 -- @reminderParser@ parses a reminder request of the form
 -- @!remind "reminder" <format>@, where format is a format that Duckling can parse.
 -- TODO: get timezone info and such ahead of time
-reminderParser :: Quoted String -> RestOfInput Text -> Message -> DatabaseDiscord SS ()
+reminderParser :: Quoted String -> RestOfInput Text -> Message -> DatabaseDiscord ()
 reminderParser (Qu content) (ROI rawString) m = do
   let tz = "Europe/London" :: Text
   tzs <- liftIO $ getTimeZoneSeriesFromOlsonFile $ "/usr/share/zoneinfo/" <> unpack tz
@@ -90,7 +87,7 @@ reminderParser (Qu content) (ROI rawString) m = do
 -- @addReminder@ takes a @time@ to remind at and the @content@ of a reminder
 -- and adds a reminder at that time. Note that this is all done in UTC, so
 -- currently ignores the user's timezone... (TODO fix)
-addReminder :: UTCTime -> String -> Message -> DatabaseDiscord SS ()
+addReminder :: UTCTime -> String -> Message -> DatabaseDiscord ()
 addReminder time content m = do
   let (Snowflake cid) = messageChannel m
       (Snowflake mid) = messageId m
@@ -100,13 +97,13 @@ addReminder time content m = do
 
 -- | @reminderCommand@ is a command implementing the functionality in
 -- @reminderParser@ and @addReminder@.
-reminderCommand :: Command SS
+reminderCommand :: Command
 reminderCommand = Command "remind" (parseComm reminderParser)
 
 -- | @reminderCron@ is a cron job that checks every minute to see if a reminder
 -- has passed, and if so sends a message using the stored information about the
 -- message originally triggering it in the database.
-reminderCron :: DatabaseDiscord SS ()
+reminderCron :: DatabaseDiscord ()
 reminderCron = do
   now <- liftIO $ systemToUTCTime <$> getSystemTime
   liftIO $ debugPrint $ "running reminder cron at " ++ show now
@@ -146,7 +143,7 @@ Uses duckling (<https://github.com/facebook/duckling>) to parse time and dates, 
 -- | @reminderPlugin@ builds a plugin providing reminder asking functionality
 -- (@reminderCommand@), reminding functionality (via the cron job specified by
 -- @reminderCron@) and the database information.
-reminderPlugin :: Plugin SS
+reminderPlugin :: Plugin
 reminderPlugin =
   (plug "reminder")
     { commands = [reminderCommand],

--- a/src/Tablebot/Plugins/Reminder.hs
+++ b/src/Tablebot/Plugins/Reminder.hs
@@ -24,14 +24,14 @@ import Data.Time.Clock.System (getSystemTime, systemToUTCTime)
 import Data.Time.LocalTime (ZonedTime, zonedTimeToUTC)
 import Data.Time.LocalTime.TimeZone.Olson.Parse (getTimeZoneSeriesFromOlsonFile)
 import Data.Word (Word64)
-import Database.Esqueleto
-import Database.Persist qualified as P (delete)
+import Database.Esqueleto hiding (delete, insert)
 import Database.Persist.TH
 import Discord.Types
 import Duckling.Core (Dimension (Time), Entity (value), Lang (EN), Region (GB), ResolvedVal (RVal), Seal (Seal), currentReftime, makeLocale, parse)
 import Duckling.Resolve (Context (..), DucklingTime, Options (..))
 import Duckling.Time.Types (InstantValue (InstantValue), SingleTimeValue (SimpleValue), TimeValue (TimeValue))
 import Tablebot.Plugin
+import Tablebot.Plugin.Database
 import Tablebot.Plugin.Discord (getMessage, sendMessage)
 import Tablebot.Plugin.SmartCommand (PComm (parseComm), Quoted (Qu), RestOfInput (ROI))
 import Tablebot.Plugin.Utils (debugPrint)
@@ -94,7 +94,7 @@ addReminder :: UTCTime -> String -> Message -> DatabaseDiscord SS ()
 addReminder time content m = do
   let (Snowflake cid) = messageChannel m
       (Snowflake mid) = messageId m
-  added <- liftSql $ insert $ Reminder cid mid time content
+  added <- insert $ Reminder cid mid time content
   let res = pack $ show $ fromSqlKey added
   sendMessage m ("Reminder " <> res <> " set for " <> (pack . show) time <> " with message `" <> pack content <> "`")
 
@@ -127,7 +127,7 @@ reminderCron = do
               sendMessage mess $
                 pack $
                   "Reminder to <@" ++ show uid ++ ">! " ++ content
-              liftSql $ P.delete (entityKey re)
+              delete (entityKey re)
 
 reminderHelp :: HelpPage
 reminderHelp =

--- a/src/Tablebot/Plugins/Reminder.hs
+++ b/src/Tablebot/Plugins/Reminder.hs
@@ -144,7 +144,7 @@ Uses duckling (<https://github.com/facebook/duckling>) to parse time and dates, 
 -- @reminderCron@) and the database information.
 reminderPlugin :: Plugin
 reminderPlugin =
-  plug
+  (plug "reminder")
     { commands = [reminderCommand],
       cronJobs = [CronJob 60000000 reminderCron],
       migrations = [reminderMigration],

--- a/src/Tablebot/Plugins/Say.hs
+++ b/src/Tablebot/Plugins/Say.hs
@@ -16,11 +16,14 @@ import Tablebot.Plugin.Discord (sendMessage)
 import Tablebot.Plugin.Parser (untilEnd)
 import Text.RawString.QQ (r)
 
+-- | @SS@ denotes the type returned by the command setup. Here its unused.
+type SS = ()
+
 -- | @say@ outputs its input.
-say :: Command
+say :: Command SS
 say = Command "say" saycomm
   where
-    saycomm :: Parser (Message -> DatabaseDiscord ())
+    saycomm :: Parser (Message -> DatabaseDiscord SS ())
     saycomm = do
       input <- untilEnd
       return $ \m -> do
@@ -39,5 +42,5 @@ Repeat the input.
     None
 
 -- | @sayPlugin@ assembles the command into a plugin.
-sayPlugin :: Plugin
+sayPlugin :: Plugin SS
 sayPlugin = (plug "say") {commands = [say], helpPages = [sayHelp]}

--- a/src/Tablebot/Plugins/Say.hs
+++ b/src/Tablebot/Plugins/Say.hs
@@ -40,4 +40,4 @@ Repeat the input.
 
 -- | @sayPlugin@ assembles the command into a plugin.
 sayPlugin :: Plugin
-sayPlugin = plug {commands = [say], helpPages = [sayHelp]}
+sayPlugin = (plug "say") {commands = [say], helpPages = [sayHelp]}

--- a/src/Tablebot/Plugins/Say.hs
+++ b/src/Tablebot/Plugins/Say.hs
@@ -16,14 +16,11 @@ import Tablebot.Plugin.Discord (sendMessage)
 import Tablebot.Plugin.Parser (untilEnd)
 import Text.RawString.QQ (r)
 
--- | @SS@ denotes the type returned by the command setup. Here its unused.
-type SS = ()
-
 -- | @say@ outputs its input.
-say :: Command SS
+say :: Command
 say = Command "say" saycomm
   where
-    saycomm :: Parser (Message -> DatabaseDiscord SS ())
+    saycomm :: Parser (Message -> DatabaseDiscord ())
     saycomm = do
       input <- untilEnd
       return $ \m -> do
@@ -42,5 +39,5 @@ Repeat the input.
     None
 
 -- | @sayPlugin@ assembles the command into a plugin.
-sayPlugin :: Plugin SS
+sayPlugin :: Plugin
 sayPlugin = (plug "say") {commands = [say], helpPages = [sayHelp]}

--- a/src/Tablebot/Plugins/Welcome.hs
+++ b/src/Tablebot/Plugins/Welcome.hs
@@ -90,4 +90,4 @@ generateCategory catClass = do
 
 -- | @welcomePlugin@ assembles these commands into a plugin.
 welcomePlugin :: Plugin
-welcomePlugin = plug {commands = [favourite], helpPages = [favouriteHelp]}
+welcomePlugin = (plug "welcome") {commands = [favourite], helpPages = [favouriteHelp]}

--- a/src/Tablebot/Plugins/Welcome.hs
+++ b/src/Tablebot/Plugins/Welcome.hs
@@ -29,7 +29,7 @@ import Text.RawString.QQ (r)
 type SS = [CategoryClass]
 
 -- | @favourite@ is the user-facing command that generates categories.
-favourite :: Command SS
+favourite :: EnvCommand SS
 favourite =
   Command
     "favourite"
@@ -93,9 +93,9 @@ generateCategory catClass = do
     getTemplate c = fromMaybe "%s" (template c)
     getInterrogative c = fromMaybe "What" (interrogative c)
 
-welcomeStartUp :: StartUp (SS)
+welcomeStartUp :: StartUp SS
 welcomeStartUp = StartUp $ liftIO readCategories
 
 -- | @welcomePlugin@ assembles these commands into a plugin.
-welcomePlugin :: Plugin SS
-welcomePlugin = (startPlug "welcome" welcomeStartUp) {commands = [favourite], helpPages = [favouriteHelp]}
+welcomePlugin :: EnvPlugin SS
+welcomePlugin = (envPlug "welcome" welcomeStartUp) {commands = [favourite], helpPages = [favouriteHelp]}

--- a/src/Tablebot/Plugins/Welcome.hs
+++ b/src/Tablebot/Plugins/Welcome.hs
@@ -10,6 +10,7 @@
 module Tablebot.Plugins.Welcome (welcomePlugin) where
 
 import Control.Monad.IO.Class
+import Control.Monad.Trans.Reader (ask)
 import Data.Aeson (FromJSON)
 import Data.Maybe (fromMaybe)
 import Data.Text (pack)
@@ -23,13 +24,18 @@ import Tablebot.Plugin.SmartCommand (PComm (parseComm))
 import Text.Printf (printf)
 import Text.RawString.QQ (r)
 
+-- | @SS@ denotes the type returned by the command setup.
+-- Here it contains the loaded categories from the yaml file so that only needs to be done once.
+type SS = [CategoryClass]
+
 -- | @favourite@ is the user-facing command that generates categories.
-favourite :: Command
+favourite :: Command SS
 favourite =
   Command
     "favourite"
     ( parseComm $ \m -> do
-        cat <- liftIO $ generateCategory =<< randomCategoryClass
+        cats <- ask
+        cat <- liftIO $ generateCategory =<< randomCategoryClass cats
         let formatted = (\(i, c) -> i ++ " is your favourite:\n> " ++ c ++ "?") cat
         sendMessage m $ pack formatted
     )
@@ -64,16 +70,15 @@ instance FromJSON FileData
 yamlFile :: FilePath
 yamlFile = "resources/welcome_messages.yaml"
 
-categories :: IO [CategoryClass]
-categories = do
+readCategories :: IO [CategoryClass]
+readCategories = do
   cats <- decodeFileEither yamlFile :: IO (Either ParseException FileData)
   return $ case cats of
     Left _ -> []
     Right out -> classes out
 
-randomCategoryClass :: IO CategoryClass
-randomCategoryClass = do
-  cats <- categories
+randomCategoryClass :: [CategoryClass] -> IO CategoryClass
+randomCategoryClass cats = do
   chooseOneWeighted getWeight cats
   where
     getWeight c = case weight c of
@@ -88,6 +93,9 @@ generateCategory catClass = do
     getTemplate c = fromMaybe "%s" (template c)
     getInterrogative c = fromMaybe "What" (interrogative c)
 
+welcomeStartUp :: StartUp (SS)
+welcomeStartUp = StartUp $ liftIO readCategories
+
 -- | @welcomePlugin@ assembles these commands into a plugin.
-welcomePlugin :: Plugin
-welcomePlugin = (plug "welcome") {commands = [favourite], helpPages = [favouriteHelp]}
+welcomePlugin :: Plugin SS
+welcomePlugin = (startPlug "welcome" welcomeStartUp) {commands = [favourite], helpPages = [favouriteHelp]}


### PR DESCRIPTION
Creates a startup action that can pass data into the main commands in a Reader.
This also incorporates the previous work on plugin disabling and reloading (I'd expected that to be merged by now, but schedules conspired against). 
Note, this changes the Monad stack, but introduces some utility features to help mitigate that in the future.
It also quite significantly changes the back-end, but hopefully this is mostly transparent to Plugin authors.

You can see an example of it in use with the welcome plugin