### PR TITLE
WIP: AnyOf to avoid Either trees

### DIFF
--- a/src/Tablebot/Plugin/SmartCommand.hs
+++ b/src/Tablebot/Plugin/SmartCommand.hs
@@ -105,7 +105,8 @@ type family AnyOf (xs :: [*]) :: * where
   AnyOf '[] = Void
   AnyOf (x ': xs) = Either x (AnyOf xs)
 
--- TODO: generate patterns for n Left.
+-- Generates patterns for AnyOf accessors.
+$(makeTupleAccessors 10)
 
 -- Various tuple instances.
 $(canParseInstances 10)

--- a/src/Tablebot/Plugin/SmartCommand.hs
+++ b/src/Tablebot/Plugin/SmartCommand.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 

--- a/src/Tablebot/Plugin/SmartCommand.hs
+++ b/src/Tablebot/Plugin/SmartCommand.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
-{-# OPTIONS_GHC -ddump-splices #-}
 
 -- |
 -- Module      : Tablebot.Plugin.SmartCommand
@@ -97,8 +96,11 @@ instance {-# OVERLAPPABLE #-} CanParse a => CanParse [a] where
 
 -- A parser for @Either a b@ attempts to parse @a@, and if that fails then
 -- attempts to parse @b@.
-instance (CanParse a, CanParse b) => CanParse (Either a b) where
+instance {-# OVERLAPPABLE #-} (CanParse a, CanParse b) => CanParse (Either a b) where
   pars = (Left <$> pars @a) <|> (Right <$> pars @b)
+
+instance {-# OVERLAPPING #-} (CanParse a) => CanParse (Either a Void) where
+  pars = Left <$> pars @a
 
 -- AnyOf, which generates a tree of Eithers for commands with many alternatives.
 type family AnyOf (xs :: [*]) :: * where

--- a/src/Tablebot/Plugin/SmartCommand.hs
+++ b/src/Tablebot/Plugin/SmartCommand.hs
@@ -99,16 +99,21 @@ instance {-# OVERLAPPABLE #-} CanParse a => CanParse [a] where
 instance {-# OVERLAPPABLE #-} (CanParse a, CanParse b) => CanParse (Either a b) where
   pars = (Left <$> pars @a) <|> (Right <$> pars @b)
 
-instance {-# OVERLAPPING #-} (CanParse a) => CanParse (Either a Void) where
-  pars = Left <$> pars @a
+instance {-# OVERLAPPABLE #-} (CanParse a, CanParse b) => CanParse (EitherS a b) where
+  pars = (LeftS <$> pars @a) <|> (RightS <$> pars @b)
+
+instance {-# OVERLAPPING #-} (CanParse a) => CanParse (EitherS a Void) where
+  pars = LeftS <$> pars @a
+
+data EitherS a b = LeftS !a | RightS !b
 
 -- AnyOf, which generates a tree of Eithers for commands with many alternatives.
 type family AnyOf (xs :: [*]) :: * where
   AnyOf '[] = Void
-  AnyOf (x ': xs) = Either x (AnyOf xs)
+  AnyOf (x ': xs) = EitherS x (AnyOf xs)
 
 -- Generates patterns for AnyOf accessors.
-$(makeTupleAccessors 10)
+$(makeChoiceAccessors 10)
 
 -- Various tuple instances.
 $(canParseInstances 10)

--- a/src/Tablebot/Plugin/SmartCommandTH.hs
+++ b/src/Tablebot/Plugin/SmartCommandTH.hs
@@ -90,4 +90,4 @@ choiceAccessor x
     decl = PatSynD (mkName $ "Choice" ++ show x) (PrefixPatSyn [var]) ImplBidir (xRightsThenLeft x)
     xRightsThenLeft :: Int -> Pat
     xRightsThenLeft 0 = ConP (mkName "LeftS") [VarP var]
-    xRightsThenLeft n = ConP (mkName "RightS") [xRightsThenLeft (n -1)]
+    xRightsThenLeft n = ConP (mkName "RightS") [xRightsThenLeft (n - 1)]

--- a/src/Tablebot/Plugin/SmartCommandTH.hs
+++ b/src/Tablebot/Plugin/SmartCommandTH.hs
@@ -1,0 +1,74 @@
+-- |
+-- Module      : Tablebot.Plugin.SmartCommandTH
+-- Description : Automatic parser generation from function types.
+-- License     : MIT
+-- Maintainer  : tagarople@gmail.com
+-- Stability   : experimental
+-- Portability : POSIX
+--
+-- TemplateHaskell helpers for SmartCommands.
+module Tablebot.Plugin.SmartCommandTH where
+
+import Data.List (intersperse)
+import Language.Haskell.TH
+
+canParseInstances :: Int -> Q [Dec]
+canParseInstances x = concat <$> mapM parseTupleInstances [2 .. x]
+
+parseTupleInstances :: Int -> Q [Dec]
+parseTupleInstances x
+  | x <= 1 = pure []
+  | otherwise = do
+    pure [iDecl]
+  where
+    -- Type variable names t1..tn
+    tvars :: [Name]
+    tvars = [mkName ('t' : show n) | n <- [1 .. x]]
+
+    -- Variable names v1..vn
+    vars :: [Name]
+    vars = [mkName ('v' : show n) | n <- [1 .. x]]
+
+    -- The instance name, CanParse
+    instName :: Name
+    instName = mkName "CanParse"
+
+    -- The n-tuple type (t1..tn).
+    signature :: Type
+    signature = foldl (\acc var -> AppT acc (VarT var)) (TupleT x) tvars
+
+    -- The context of (CanParse t1, ... CanParse tn).
+    cxt :: Cxt
+    cxt = map (\var -> AppT (ConT instName) (VarT var)) tvars
+
+    -- instance (CanParse t1... CanParse tn) => CanParse (t1, ... , tn) where
+    iDecl :: Dec
+    iDecl = InstanceD Nothing cxt (AppT (ConT instName) signature) [mDecl]
+
+    -- pars = do
+    --   x <- pars
+    --   space
+    --   ...
+    --   return (x, ...)
+    mDecl :: Dec
+    mDecl = FunD (mkName "pars") [Clause [] body []]
+
+    -- A do statement containing the relevant instructions.
+    body :: Body
+    body = NormalB . DoE $ intersperseSpace parseArgs ++ [returnArgs]
+
+    -- Separate each parse with a space.
+    intersperseSpace :: [Stmt] -> [Stmt]
+    intersperseSpace = intersperse (NoBindS $ VarE (mkName "space"))
+
+    -- Parse each type into its corresponding var.
+    parseArgs :: [Stmt]
+    parseArgs = zipWith genBind vars tvars
+
+    -- Generates the pattern x <- pars @a.
+    genBind :: Name -> Name -> Stmt
+    genBind var ty = BindS (VarP var) (AppTypeE (VarE (mkName "pars")) (VarT ty))
+
+    -- return (x, ...)
+    returnArgs :: Stmt
+    returnArgs = NoBindS $ AppE (VarE (mkName "return")) $ TupE $ map (Just . VarE) vars

--- a/src/Tablebot/Plugin/SmartCommandTH.hs
+++ b/src/Tablebot/Plugin/SmartCommandTH.hs
@@ -87,8 +87,7 @@ tupleAccessor x
   where
     var = mkName "x"
     decl :: Dec
-    decl = PatSynD (mkName $ "Choice" ++ show x) (PrefixPatSyn [var]) ImplBidir (xRightsThenLeft x)
+    decl = PatSynD (mkName $ "Choice" ++ show x) (PrefixPatSyn [var]) Unidir (xRightsThenLeft x)
     xRightsThenLeft :: Int -> Pat
-    xRightsThenLeft 0 = VarP var
-    xRightsThenLeft 1 = ConP (mkName "Left") [VarP var]
+    xRightsThenLeft 0 = ConP (mkName "Left") [VarP var]
     xRightsThenLeft n = ConP (mkName "Right") [xRightsThenLeft (n -1)]

--- a/src/Tablebot/Plugin/SmartCommandTH.hs
+++ b/src/Tablebot/Plugin/SmartCommandTH.hs
@@ -87,7 +87,7 @@ tupleAccessor x
   where
     var = mkName "x"
     decl :: Dec
-    decl = PatSynD (mkName $ "Choice" ++ show x) (PrefixPatSyn [var]) Unidir (xRightsThenLeft x)
+    decl = PatSynD (mkName $ "Choice" ++ show x) (PrefixPatSyn [var]) ImplBidir (xRightsThenLeft x)
     xRightsThenLeft :: Int -> Pat
     xRightsThenLeft 0 = ConP (mkName "Left") [VarP var]
     xRightsThenLeft n = ConP (mkName "Right") [xRightsThenLeft (n -1)]

--- a/src/Tablebot/Plugin/SmartCommandTH.hs
+++ b/src/Tablebot/Plugin/SmartCommandTH.hs
@@ -9,7 +9,7 @@
 -- Portability : POSIX
 --
 -- TemplateHaskell helpers for SmartCommands.
-module Tablebot.Plugin.SmartCommandTH where
+module Tablebot.Plugin.SmartCommandTH (canParseInstances, makeChoiceAccessors) where
 
 import Data.List (intersperse)
 import Language.Haskell.TH
@@ -75,13 +75,13 @@ parseTupleInstances x
     returnArgs :: Stmt
     returnArgs = NoBindS $ AppE (VarE (mkName "return")) $ TupE $ map (Just . VarE) vars
 
-makeTupleAccessors :: Int -> Q [Dec]
-makeTupleAccessors x = concat <$> mapM tupleAccessor [0 .. x]
+makeChoiceAccessors :: Int -> Q [Dec]
+makeChoiceAccessors x = concat <$> mapM choiceAccessor [0 .. x]
 
 -- Builds ChoiceN, which accesses the nth element of an AnyOf.
 -- NOTE: accessor 0 is Left, 1 is Left . Right, 2 is Left . Right . Right and so on.
-tupleAccessor :: Int -> Q [Dec]
-tupleAccessor x
+choiceAccessor :: Int -> Q [Dec]
+choiceAccessor x
   | x < 0 = pure []
   | otherwise = pure [decl]
   where
@@ -89,5 +89,5 @@ tupleAccessor x
     decl :: Dec
     decl = PatSynD (mkName $ "Choice" ++ show x) (PrefixPatSyn [var]) ImplBidir (xRightsThenLeft x)
     xRightsThenLeft :: Int -> Pat
-    xRightsThenLeft 0 = ConP (mkName "Left") [VarP var]
-    xRightsThenLeft n = ConP (mkName "Right") [xRightsThenLeft (n -1)]
+    xRightsThenLeft 0 = ConP (mkName "LeftS") [VarP var]
+    xRightsThenLeft n = ConP (mkName "RightS") [xRightsThenLeft (n -1)]

--- a/src/Tablebot/Plugins/Quote.hs
+++ b/src/Tablebot/Plugins/Quote.hs
@@ -46,15 +46,17 @@ quote =
 quoteComm ::
   WithError
     "Unknown quote functionality."
-    ( Either
-        (Exactly "add", Quoted String, Exactly "-", RestOfInput String)
-        (Either (Exactly "show", Int) (Exactly "delete", Int))
+    ( AnyOf
+        '[ (Exactly "add", Quoted String, Exactly "-", RestOfInput String),
+           (Exactly "show", Int),
+           (Exactly "delete", Int)
+         ]
     ) ->
   Message ->
   DatabaseDiscord ()
-quoteComm (WErr (Left (_, Qu qu, _, ROI author))) = addQ qu author
-quoteComm (WErr (Right (Left (_, qId)))) = showQ (fromIntegral qId)
-quoteComm (WErr (Right (Right (_, qId)))) = deleteQ (fromIntegral qId)
+quoteComm (WErr (Choice0 (_, Qu qu, _, ROI author))) = addQ qu author
+quoteComm (WErr (Choice1 (_, qId))) = showQ (fromIntegral qId)
+quoteComm (WErr (Choice2 (_, qId))) = deleteQ (fromIntegral qId)
 
 -- | @addQuote@, which looks for a message of the form
 -- @!quote add "quoted text" - author@, and then stores said quote in the

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/9.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/18.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -62,8 +62,8 @@ packages:
     hackage: esqueleto-3.4.1.1
 snapshots:
 - completed:
-    size: 567037
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/9.yaml
-    sha256: d7d8d5106e53d1669964bd8bd2b0f88a5ad192d772f5376384b76738fd992311
+    size: 586296
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/18.yaml
+    sha256: 63539429076b7ebbab6daa7656cfb079393bf644971156dc349d7c0453694ac2
   original:
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/9.yaml
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/18.yaml


### PR DESCRIPTION
Instead of doing `Either a (Either b (Either c...)))`, you can now use `AnyOf '[a, b, c...]` which also provides `Choice0`, `Choice1` and so on to pattern match on the inputs. Quote.hs has been updated to show this at work.

The linter is unhappy with this, saying that the patterns are incomplete when they are really complete. Will continue to investigate, as I wonder if I've just messed up (especially after moving to strict types so it should just work).