### PR TITLE
Better error messages from the parser

### DIFF
--- a/src/Tablebot/Handler/Command.hs
+++ b/src/Tablebot/Handler/Command.hs
@@ -73,7 +73,7 @@ instance ShowErrorComponent ReadableError where
       commaSep :: [String] -> String
       commaSep [] = ""
       commaSep [x] = x <> "."
-      commaSep [x, y] = x <> " or " <> y
+      commaSep [x, y] = x <> " or " <> y <> "."
       commaSep (x : xs) = x <> ", " <> commaSep xs
 
 makeBundleReadable :: ParseErrorBundle Text Void -> ParseErrorBundle Text ReadableError

--- a/src/Tablebot/Handler/Command.hs
+++ b/src/Tablebot/Handler/Command.hs
@@ -16,7 +16,11 @@ module Tablebot.Handler.Command
   )
 where
 
+import qualified Data.List.NonEmpty as NE
+import Data.Set (singleton, toList)
 import Data.Text (Text, isPrefixOf)
+import Data.Void (Void)
+import Debug.Trace (traceShowId)
 import Discord.Types (Message (messageText))
 import Tablebot.Handler.Plugins (changeAction)
 import Tablebot.Handler.Types
@@ -46,7 +50,7 @@ parseNewMessage pl prefix m =
 parseCommands :: [CompiledCommand] -> Message -> Text -> CompiledDatabaseDiscord ()
 parseCommands cs m prefix = case parse (parser cs) "" (messageText m) of
   Right p -> p m
-  Left e -> changeAction () . sendEmbedMessage m "" $ embedError $ ParserException $ "```\n" ++ errorBundlePretty e ++ "```"
+  Left e -> changeAction () . sendEmbedMessage m "" $ embedError $ ParserException $ "```\n" ++ errorBundlePretty (makeBundleReadable e) ++ "```"
   where
     parser :: [CompiledCommand] -> Parser (Message -> CompiledDatabaseDiscord ())
     parser cs' =
@@ -56,6 +60,41 @@ parseCommands cs m prefix = case parse (parser cs) "" (messageText m) of
         <|> pure (\_ -> pure ())
     toErroringParser :: CompiledCommand -> Parser (Message -> CompiledDatabaseDiscord ())
     toErroringParser c = try (chunk $ commandName c) *> (skipSpace1 <|> eof) *> (try (choice $ map toErroringParser $ commandSubcommands c) <|> commandParser c)
+
+data ReadableError = UnknownError | KnownError String [String]
+  deriving (Show, Eq, Ord)
+
+instance ShowErrorComponent ReadableError where
+  showErrorComponent UnknownError = "Unknown error!"
+  showErrorComponent (KnownError l possibles) =
+    l <> ending
+    where
+      ending = if null possibles then "" else "\nMaybe you meant one of: " <> commaSep possibles
+      commaSep :: [String] -> String
+      commaSep [] = ""
+      commaSep [x] = x <> "."
+      commaSep [x, y] = x <> " or " <> y
+      commaSep (x : xs) = x <> ", " <> commaSep xs
+
+makeBundleReadable :: ParseErrorBundle Text Void -> ParseErrorBundle Text ReadableError
+makeBundleReadable (ParseErrorBundle errs state) = ParseErrorBundle (NE.map makeReadable errs) state
+
+-- | Transform our errors into more useful ones.
+-- This uses the Label hidden within each error to build an error message,
+-- as we have used labels to give parsers user-facing errors.
+makeReadable :: ParseError Text Void -> ParseError Text ReadableError
+makeReadable (TrivialError i _ good) =
+  let (lab, others) = getLabel (toList good)
+   in case lab of
+        Just l -> FancyError i . singleton . ErrorCustom $ KnownError l others
+        Nothing -> FancyError i . singleton $ ErrorCustom UnknownError
+  where
+    getLabel :: [ErrorItem (Token Text)] -> (Maybe String, [String])
+    getLabel [] = (Nothing, [])
+    getLabel ((Tokens nel) : xs) = (Nothing, [NE.toList nel]) <> getLabel xs
+    getLabel ((Label ls) : xs) = (Just (NE.toList ls), []) <> getLabel xs
+    getLabel (EndOfInput : xs) = (Nothing, ["no more input"]) <> getLabel xs
+makeReadable e = mapParseError (const UnknownError) e
 
 -- | Given a list of 'InlineCommand' @cs@ and a message @m@, run each inline
 -- command's parser on the message text until one succeeds. Errors are not sent

--- a/src/Tablebot/Handler/Command.hs
+++ b/src/Tablebot/Handler/Command.hs
@@ -84,9 +84,14 @@ makeBundleReadable (ParseErrorBundle errs state) =
    in (ParseErrorBundle errors state, getTitle $ NE.toList title)
   where
     getTitle :: [Maybe String] -> String
-    getTitle titles = case catMaybes titles of
-      (x : xs) -> if null xs then x else x ++ " (and " ++ show (length xs) ++ " more)"
-      [] -> "Parser Error"
+    -- Safety proof for application of `head`: we filter by `not . null` so each element is nonempty.
+    getTitle titles = case filter (not . null) $ catMaybes titles of
+      -- therefore, `x` is nonempty, so `lines x` is nonempty, meaning that `head (lines x)` is fine,
+      -- since `lines x` is nonempty for nonempty input.
+      (x : xs) ->
+        let title = head (lines x)
+         in if null xs then title else title ++ " (and " ++ show (length xs) ++ " more)"
+      [] -> "Parser Error!"
 
 -- | Transform our errors into more useful ones.
 -- This uses the Label hidden within each error to build an error message,

--- a/src/Tablebot/Plugin/Exception.hs
+++ b/src/Tablebot/Plugin/Exception.hs
@@ -31,7 +31,7 @@ import Tablebot.Plugin.Types (DiscordColour (..))
 data BotException
   = GenericException String String
   | MessageSendException String
-  | ParserException String
+  | ParserException String String
   | IndexOutOfBoundsException Int (Int, Int)
   | RandomException String
   deriving (Show, Eq)
@@ -104,7 +104,7 @@ errorInfo :: BotException -> ErrorInfo
 -- declare new errors in the definition of BotException.
 errorInfo (GenericException name' msg') = ErrorInfo name' msg'
 errorInfo (MessageSendException msg') = ErrorInfo "MessageSendException" msg'
-errorInfo (ParserException msg') = ErrorInfo "ParserException" msg'
+errorInfo (ParserException title msg') = ErrorInfo title msg'
 errorInfo (IndexOutOfBoundsException index (a, b)) =
   ErrorInfo
     "IndexOutOfBoundsException"

--- a/src/Tablebot/Plugin/SmartCommand.hs
+++ b/src/Tablebot/Plugin/SmartCommand.hs
@@ -19,7 +19,7 @@ import Data.Text (Text, pack)
 import Discord.Types (Message)
 import GHC.TypeLits
 import Tablebot.Plugin.Parser
-import Tablebot.Plugin.Types (DatabaseDiscord, EnvDatabaseDiscord, Parser)
+import Tablebot.Plugin.Types (EnvDatabaseDiscord, Parser)
 import Text.Megaparsec
 
 -- | @PComm@ defines function types that we can automatically turn into parsers

--- a/src/Tablebot/Plugins/Quote.hs
+++ b/src/Tablebot/Plugins/Quote.hs
@@ -96,23 +96,34 @@ quoteComm ::
   DatabaseDiscord ()
 quoteComm (WErr ()) = randomQ
 
-addComm :: (Quoted Text, Exactly "-", RestOfInput Text) -> Message -> DatabaseDiscord ()
-addComm (Qu qu, _, ROI author) = addQ qu author
+addComm ::
+  WithError "Quote format should be \"quote\" - author!" (Quoted Text, Exactly "-", RestOfInput Text) ->
+  Message ->
+  DatabaseDiscord ()
+addComm (WErr (Qu qu, _, ROI author)) = addQ qu author
 
-editComm :: (Int64, Quoted Text, Exactly "-", RestOfInput Text) -> Message -> DatabaseDiscord ()
-editComm (qId, Qu qu, _, ROI author) = editQ qId qu author
+editComm ::
+  WithError
+    "Edit format should be quoteId \"new quote\" - new author!"
+    (Int64, Quoted Text, Exactly "-", RestOfInput Text) ->
+  Message ->
+  DatabaseDiscord ()
+editComm (WErr (qId, Qu qu, _, ROI author)) = editQ qId qu author
 
 thisComm :: Message -> DatabaseDiscord ()
 thisComm = thisQ
 
-authorComm :: RestOfInput Text -> Message -> DatabaseDiscord ()
-authorComm (ROI author) = authorQ author
+authorComm ::
+  WithError "Expected author name to find quotes for!" (RestOfInput Text) ->
+  Message ->
+  DatabaseDiscord ()
+authorComm (WErr (ROI author)) = authorQ author
 
-showComm :: Int64 -> Message -> DatabaseDiscord ()
-showComm qId = showQ qId
+showComm :: WithError "Expected quote number to show!" Int64 -> Message -> DatabaseDiscord ()
+showComm (WErr qId) = showQ qId
 
-deleteComm :: Int64 -> Message -> DatabaseDiscord ()
-deleteComm qId = deleteQ qId
+deleteComm :: WithError "Expected quote number to delete!" Int64 -> Message -> DatabaseDiscord ()
+deleteComm (WErr qId) = deleteQ qId
 
 randomComm :: Message -> DatabaseDiscord ()
 randomComm = randomQ

--- a/src/Tablebot/Plugins/Quote.hs
+++ b/src/Tablebot/Plugins/Quote.hs
@@ -79,7 +79,7 @@ addQuote :: Command
 addQuote = Command "add" (parseComm addComm) []
   where
     addComm ::
-      WithError "Quote format should be \"quote\" - author!" (Quoted Text, Exactly "-", RestOfInput Text) ->
+      WithError "Quote format incorrect!\nFormat is: .quote \"quote\" - author" (Quoted Text, Exactly "-", RestOfInput Text) ->
       Message ->
       DatabaseDiscord ()
     addComm (WErr (Qu qu, _, ROI author)) = addQ qu author
@@ -89,7 +89,7 @@ editQuote = Command "edit" (parseComm editComm) []
   where
     editComm ::
       WithError
-        "Edit format should be quoteId \"new quote\" - new author!"
+        "Edit format incorrect!\nFormat is: .quote edit quoteId \"new quote\" - author"
         (Int64, Quoted Text, Exactly "-", RestOfInput Text) ->
       Message ->
       DatabaseDiscord ()
@@ -105,7 +105,7 @@ authorQuote :: Command
 authorQuote = Command "author" (parseComm authorComm) []
   where
     authorComm ::
-      WithError "Expected author name to find quotes for!" (RestOfInput Text) ->
+      WithError "Quote format incorrect!\nExpected author name to find quotes for after .quote author" (RestOfInput Text) ->
       Message ->
       DatabaseDiscord ()
     authorComm (WErr (ROI author)) = authorQ author
@@ -113,13 +113,19 @@ authorQuote = Command "author" (parseComm authorComm) []
 showQuote :: Command
 showQuote = Command "show" (parseComm showComm) []
   where
-    showComm :: WithError "Expected quote number to show!" Int64 -> Message -> DatabaseDiscord ()
+    showComm ::
+      WithError "Quote format incorrect!\nExpected quote number to show, e.g. .quote show 420" Int64 ->
+      Message ->
+      DatabaseDiscord ()
     showComm (WErr qId) = showQ qId
 
 deleteQuote :: Command
 deleteQuote = Command "delete" (parseComm deleteComm) []
   where
-    deleteComm :: WithError "Expected quote number to delete!" Int64 -> Message -> DatabaseDiscord ()
+    deleteComm ::
+      WithError "Quote format incorrect!\nExpected quote number to delete, e.g. .quote delete 420" Int64 ->
+      Message ->
+      DatabaseDiscord ()
     deleteComm (WErr qId) = deleteQ qId
 
 randomQuote :: Command

--- a/src/Tablebot/Plugins/Quote.hs
+++ b/src/Tablebot/Plugins/Quote.hs
@@ -79,9 +79,9 @@ addQuote :: Command
 addQuote = Command "add" (parseComm addComm) []
   where
     addComm ::
-     WithError "Quote format should be \"quote\" - author!" (Quoted Text, Exactly "-", RestOfInput Text) ->
-     Message ->
-     DatabaseDiscord ()
+      WithError "Quote format should be \"quote\" - author!" (Quoted Text, Exactly "-", RestOfInput Text) ->
+      Message ->
+      DatabaseDiscord ()
     addComm (WErr (Qu qu, _, ROI author)) = addQ qu author
 
 editQuote :: Command

--- a/src/Tablebot/Plugins/Reminder.hs
+++ b/src/Tablebot/Plugins/Reminder.hs
@@ -72,7 +72,7 @@ ducklingDateTime now rawString = do
 -- @!remind "reminder" <format>@, where format is a format that Duckling can parse.
 -- TODO: get timezone info and such ahead of time
 reminderParser ::
-  WithError "Reminder needs a reminder (in quotes) followed by the time to be reminded at!" (Quoted String, RestOfInput Text) ->
+  WithError "Incorrect reminder format!\nReminder needs a reminder (in quotes) followed by the time to be reminded at." (Quoted String, RestOfInput Text) ->
   Message ->
   DatabaseDiscord ()
 reminderParser (WErr (Qu content, ROI rawString)) m = do

--- a/src/Tablebot/Plugins/Reminder.hs
+++ b/src/Tablebot/Plugins/Reminder.hs
@@ -101,10 +101,7 @@ addReminder time content m = do
 -- | @reminderCommand@ is a command implementing the functionality in
 -- @reminderParser@ and @addReminder@.
 reminderCommand :: Command
-reminderCommand = Command "remind" (parseComm errorReminderParser) []
-  where
-    errorReminderParser :: WithError "Unknown reminder functionality." (Quoted String, RestOfInput Text) -> Message -> DatabaseDiscord ()
-    errorReminderParser (WErr (a, b)) = reminderParser a b
+reminderCommand = Command "remind" (parseComm reminderParser) []
 
 -- | @reminderCron@ is a cron job that checks every minute to see if a reminder
 -- has passed, and if so sends a message using the stored information about the

--- a/src/Tablebot/Plugins/Reminder.hs
+++ b/src/Tablebot/Plugins/Reminder.hs
@@ -33,7 +33,7 @@ import Duckling.Time.Types (InstantValue (InstantValue), SingleTimeValue (Simple
 import Tablebot.Plugin
 import Tablebot.Plugin.Database
 import Tablebot.Plugin.Discord (getMessage, sendMessage)
-import Tablebot.Plugin.SmartCommand (PComm (parseComm), Quoted (Qu), RestOfInput (ROI))
+import Tablebot.Plugin.SmartCommand (PComm (parseComm), Quoted (Qu), RestOfInput (ROI), WithError (..))
 import Tablebot.Plugin.Utils (debugPrint)
 import Text.RawString.QQ (r)
 
@@ -71,8 +71,11 @@ ducklingDateTime now rawString = do
 -- @reminderParser@ parses a reminder request of the form
 -- @!remind "reminder" <format>@, where format is a format that Duckling can parse.
 -- TODO: get timezone info and such ahead of time
-reminderParser :: Quoted String -> RestOfInput Text -> Message -> DatabaseDiscord ()
-reminderParser (Qu content) (ROI rawString) m = do
+reminderParser ::
+  WithError "Reminder needs a reminder (in quotes) followed by the time to be reminded at!" (Quoted String, RestOfInput Text) ->
+  Message ->
+  DatabaseDiscord ()
+reminderParser (WErr (Qu content, ROI rawString)) m = do
   let tz = "Europe/London" :: Text
   tzs <- liftIO $ getTimeZoneSeriesFromOlsonFile $ "/usr/share/zoneinfo/" <> unpack tz
   now <- liftIO $ currentReftime (singleton tz tzs) tz

--- a/src/Tablebot/Plugins/Shibe.hs
+++ b/src/Tablebot/Plugins/Shibe.hs
@@ -10,10 +10,9 @@
 module Tablebot.Plugins.Shibe (shibePlugin) where
 
 import Control.Monad.IO.Class (MonadIO (liftIO))
-import Data.Aeson (FromJSON, eitherDecode)
+import Data.Aeson (eitherDecode)
 import Data.Functor ((<&>))
 import Data.Text (Text, pack)
-import GHC.Generics (Generic)
 import Network.HTTP.Conduit (Response (responseBody), parseRequest)
 import Network.HTTP.Simple (httpLBS)
 import Tablebot.Plugin.Discord (Message, sendMessage)

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/9.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/18.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/tutorials/2.Exceptions.md
+++ b/tutorials/2.Exceptions.md
@@ -131,7 +131,7 @@ The type for exceptions in Tablebot is `BotException`:
 data BotException
   = GenericException String String
   | MessageSendException String
-  | ParserException
+  | ParserException String
   | RandomException String
   | IndexOutOfBoundsException Int (Int, Int)
   | ...


### PR DESCRIPTION
The parser now spits out more human-friendly error messages. This is done by reporting the label of the most recently failed parser. (I expect this to have weird behaviour on anything that does not have a label, but all user-facing plugins should have errors using `WithError` or `<?>`.)

Reminder and Quote are also updated to make sure that all paths have errors.

While different to that originally proposed in #7, it still fixes that issue.