### PR TITLE
Fixed SmartParser for Maybe values

### DIFF
--- a/src/Tablebot/Utility/SmartParser.hs
+++ b/src/Tablebot/Utility/SmartParser.hs
@@ -74,11 +74,13 @@ instance IsString a => CanParse (Quoted a) where
 -- correctly parsed, else @Nothing@.
 instance CanParse a => CanParse (Maybe a) where
   pars = optional $ try (pars @a)
+
   -- Note: we override @parsThenMoveToNext@:
   -- there will be no spaces to parse if the argument isn't present.
-  parsThenMoveToNext = pars >>= \case
-    Nothing -> return Nothing
-    Just val -> Just val <$ (eof <|> skipSpace1)
+  parsThenMoveToNext =
+    pars >>= \case
+      Nothing -> return Nothing
+      Just val -> Just val <$ (eof <|> skipSpace1)
 
 -- A parser for @[a]@ parses any number of @a@s.
 instance {-# OVERLAPPABLE #-} CanParse a => CanParse [a] where

--- a/src/Tablebot/Utility/SmartParser.hs
+++ b/src/Tablebot/Utility/SmartParser.hs
@@ -46,13 +46,14 @@ instance {-# OVERLAPPING #-} CanParse a => PComm (a -> Message -> EnvDatabaseDis
 -- Recursive case is to parse the domain of the function type, then the rest.
 instance {-# OVERLAPPABLE #-} (CanParse a, PComm as s) => PComm (a -> as) s where
   parseComm comm = do
-    this <- pars @a
-    skipSpace1
+    this <- parsThenMoveToNext @a
     parseComm (comm this)
 
 -- | @CanParse@ defines types from which we can generate parsers.
 class CanParse a where
   pars :: Parser a
+  parsThenMoveToNext :: Parser a
+  parsThenMoveToNext = pars <* (eof <|> skipSpace1)
 
 -- Note: since FromString and (Read, Integral) can overlap, we cannot specify
 -- this instance as FromString a => CanParse a.
@@ -73,6 +74,11 @@ instance IsString a => CanParse (Quoted a) where
 -- correctly parsed, else @Nothing@.
 instance CanParse a => CanParse (Maybe a) where
   pars = optional $ try (pars @a)
+  -- Note: we override @parsThenMoveToNext@:
+  -- there will be no spaces to parse if the argument isn't present.
+  parsThenMoveToNext = pars >>= \case
+    Nothing -> return Nothing
+    Just val -> Just val <$ (eof <|> skipSpace1)
 
 -- A parser for @[a]@ parses any number of @a@s.
 instance {-# OVERLAPPABLE #-} CanParse a => CanParse [a] where


### PR DESCRIPTION
Closes #69.

Changed the `CanParse` class to add `parsThenMoveToNext`, which parses the value and then moves to the next argument (if there is one). The function is overriden in the instance for `Maybe a` so that if the argument isn't present no subsequent spaces are expected.

The [broken plugin referenced in #69](https://github.com/L0neGamer/tablebot/blob/smartcommand-maybe/src/Tablebot/Plugins/BrokenCase.hs) now works as expected:

![image](https://user-images.githubusercontent.com/12686053/147925765-c9025b53-e08d-4da0-aca4-1bf1cfbf7de0.png)
