### PR TITLE
$say now puts newlines in quote-blocks

### DIFF
--- a/src/Tablebot/Plugins/Say.hs
+++ b/src/Tablebot/Plugins/Say.hs
@@ -24,7 +24,8 @@ say = Command "say" saycomm []
     saycomm = do
       input <- untilEnd
       return $ \m -> do
-        sendMessage m $ pack $ "> " ++ input ++ "\n - <@" ++ show (userId $ messageAuthor m) ++ ">"
+        let quoted = unlines . (("> " ++) <$>) . lines
+        sendMessage m $ pack $ quoted input ++ " - <@" ++ show (userId $ messageAuthor m) ++ ">"
 
 sayHelp :: HelpPage
 sayHelp =


### PR DESCRIPTION
Closes #88.

Quote blocks in Discord's markdown require every line of the quoted text to be prefixed with `> `.

This should now work as expected:

![image](https://user-images.githubusercontent.com/12686053/147927103-4b30c68a-46b2-4429-bfa9-005cbb6ca3a4.png)
