### PR TITLE
$flip now correctly parses quoted strings

### DIFF
--- a/src/Tablebot/Plugins/Flip.hs
+++ b/src/Tablebot/Plugins/Flip.hs
@@ -26,7 +26,7 @@ flip = Command "flip" flipcomm []
   where
     flipcomm :: Parser (Message -> DatabaseDiscord ())
     flipcomm = do
-      args <- (try quoted <|> nonSpaceWord) `sepBy` space
+      args <- (try quoted <|> nonSpaceWord) `sepBy` some space
       return $ \m -> do
         c <- case length args of
           0 -> liftIO $ chooseOneWithDefault "" ["Heads", "Tails"]

--- a/src/Tablebot/Plugins/Flip.hs
+++ b/src/Tablebot/Plugins/Flip.hs
@@ -26,7 +26,7 @@ flip = Command "flip" flipcomm []
   where
     flipcomm :: Parser (Message -> DatabaseDiscord ())
     flipcomm = do
-      args <- nonSpaceWord `sepBy` space
+      args <- (try quoted <|> nonSpaceWord) `sepBy` space
       return $ \m -> do
         c <- case length args of
           0 -> liftIO $ chooseOneWithDefault "" ["Heads", "Tails"]


### PR DESCRIPTION
Closes #95.

The `flip` command will now attempt to parse a quoted string before accepting a series of non-space characters.

![image](https://user-images.githubusercontent.com/12686053/147929042-f0c764b0-967b-4a65-a34a-829bfd777f4d.png)

When given dangling quotes, the parser will parse them as part of a non-space word. For example: `$flip 1" "2 "3 4"` will choose from `1"`, `"2`, and `3 4`.


