### PR TITLE
Fix for some bracket values being parsed incorrectly

### DIFF
--- a/src/Tablebot/Plugins/Roll/Dice/DiceParsing.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceParsing.hs
@@ -39,13 +39,12 @@ failure' s ss = failure (Just $ Tokens $ NE.fromList $ T.unpack s) (S.map (Token
 instance CanParse ListValues where
   pars =
     do
-      LVBase <$> pars
-      <|> functionParser listFunctions LVFunc
+      functionParser listFunctions LVFunc
       <|> ( do
-              nb <- pars
-              _ <- char '#'
+              nb <- try (pars <* char '#')
               MultipleValues nb <$> pars
           )
+      <|> LVBase <$> pars
 
 instance CanParse ListValuesBase where
   pars = do
@@ -56,7 +55,7 @@ instance CanParse ListValuesBase where
               <* (char '}' <??> "could not find closing brace for list")
           )
       <|> LVBParen . unnest
-      <$> try pars
+      <$> pars
     where
       unnest (Paren (LVBase (LVBParen e))) = e
       unnest e = e

--- a/src/Tablebot/Plugins/Roll/Dice/DiceParsing.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceParsing.hs
@@ -56,7 +56,7 @@ instance CanParse ListValuesBase where
               <* (char '}' <??> "could not find closing brace for list")
           )
       <|> LVBParen . unnest
-      <$> pars
+      <$> try pars
     where
       unnest (Paren (LVBase (LVBParen e))) = e
       unnest e = e


### PR DESCRIPTION
Parsing order changed for ListValues to try to prevent bad errors happening when they shouldn't.

First, try to parse a list function. Then try to parse the MultipleValues value. Then try and parse a base list value.