### PR TITLE
updated roll link

### DIFF
--- a/src/Tablebot/Plugins/Roll/Plugin.hs
+++ b/src/Tablebot/Plugins/Roll/Plugin.hs
@@ -120,7 +120,7 @@ This supports addition, subtraction, multiplication, integer division, exponenti
       ++ unpack (intercalate ", " listFunctionsList)
       ++ [r| (which return lists).
 
-To see a full list of uses, options and limitations, please go to <https://github.com/WarwickTabletop/tablebot/blob/main/docs/Roll.md>.
+To see a full list of uses, options and limitations, please go to <https://github.com/WarwickTabletop/tablebot/blob/stable/docs/Roll.md>.
 
 *Usage:*
   - `roll 1d20` -> rolls a twenty sided die and returns the outcome


### PR DESCRIPTION
updated the link to the help page for roll to refer to the stable branch so the main bot always links to the correct help page.