### PR TITLE
Better config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ to be called when DEBUG is false. Users with the superuser group are able to run
 ones), so caution should be used when setting these up.
 
 If you have any difficulties setting it up, see the [contributor's guide](CONTRIBUTING.md) for a walkthrough.
+
+## Importing this bot and running it yourself.
+
+If you like, rather than directly running this bot you can run it yourself with minor tweaks. An example of this is in `app/Main.hs` - tweak this to your needs and then run `stack run` as per usual.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,16 +2,16 @@
 
 module Main where
 
-import Data.Default
 import Data.Text (Text)
 import Tablebot (BotConfig (..), runTablebotWithEnv)
 import Tablebot.Plugins (allPlugins)
 
 -- @main@ runs forever. This allows bot reloading by fully shutting down the bot and letting it restart.
 main :: IO ()
-main = runTablebotWithEnv allPlugins $ def {gamePlaying = Just "Cosmic Encounter", rootHelpText = Just rootBody}
+main = runTablebotWithEnv allPlugins $ BotConfig {gamePlaying = "with dice", rootHelpText = rootBody}
 
 rootBody :: Text
 rootBody =
-  "**Test Bot**\n\
-  \This bot is for testing, so should not be trusted."
+  "**Tabletop Bot**\n\
+  \This friendly little bot provides several tools to help with\
+  \ the running of the Warwick Tabletop Games and Role-Playing Society Discord server."

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,8 +1,17 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main where
 
-import Tablebot (runTablebotWithEnv)
+import Data.Default
+import Data.Text (Text)
+import Tablebot (BotConfig (..), runTablebotWithEnv)
 import Tablebot.Plugins (allPlugins)
 
 -- @main@ runs forever. This allows bot reloading by fully shutting down the bot and letting it restart.
 main :: IO ()
-main = runTablebotWithEnv allPlugins
+main = runTablebotWithEnv allPlugins $ def {gamePlaying = Just "Cosmic Encounter", rootHelpText = Just rootBody}
+
+rootBody :: Text
+rootBody =
+  "**Test Bot**\n\
+  \This bot is for testing, so should not be trusted."

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,38 +1,8 @@
 module Main where
 
-import Control.Concurrent.MVar (MVar, newMVar, swapMVar)
-import Control.Monad (forever, unless)
-import Control.Monad.Extra
-import Data.Maybe (fromMaybe)
-import Data.Text (pack)
-import Data.Text.Encoding (encodeUtf8)
-import LoadEnv (loadEnv)
-import Paths_tablebot (version)
-import System.Environment (getEnv, lookupEnv)
-import System.Exit (die)
-import Tablebot (runTablebot)
-import Tablebot.Internal.Administration
-import Tablebot.Plugins (plugins)
-import Tablebot.Utility.Types
-import Text.Regex.PCRE
+import Tablebot (runTablebotWithEnv)
+import Tablebot.Plugins (allPlugins)
 
 -- @main@ runs forever. This allows bot reloading by fully shutting down the bot and letting it restart.
 main :: IO ()
-main = do
-  -- fetch the version info as soon after building to reduce the likelihood that it changes between build and run
-  gv <- gitVersion
-  let vInfo = VInfo gv version
-  rFlag <- newMVar Reload :: IO (MVar ShutdownReason)
-  whileM $ do
-    _ <- swapMVar rFlag Reload
-    loadEnv
-    dToken <- pack <$> getEnv "DISCORD_TOKEN"
-    unless (encodeUtf8 dToken =~ ("^[A-Za-z0-9_-]{24}[.][A-Za-z0-9_-]{6}[.][A-Za-z0-9_-]{27}$" :: String)) $
-      die "Invalid token format. Please check it is a bot token"
-    prefix <- pack . fromMaybe "!" <$> lookupEnv "PREFIX"
-    dbpath <- getEnv "SQLITE_FILENAME"
-    runTablebot vInfo dToken prefix dbpath (plugins rFlag)
-    exit <- swapMVar rFlag Reload
-    restartAction exit
-    pure $ not (restartIsTerminal exit)
-  putStrLn "Tablebot closed"
+main = runTablebotWithEnv allPlugins

--- a/src/Tablebot.hs
+++ b/src/Tablebot.hs
@@ -9,7 +9,7 @@
 -- Portability : POSIX
 --
 -- This module contains the main runner for Tablebot. If you're just looking to
--- run the bot with existing plugins, importing this and your favourite plugins
+-- run the bot with existing plugins, import this and your favourite plugins
 -- from "Tablebot.Plugins".
 module Tablebot
   ( runTablebot,
@@ -48,6 +48,10 @@ import Tablebot.Utility
 import Tablebot.Utility.Help
 import Text.Regex.PCRE ((=~))
 
+-- | runTablebotWithEnv @plugins@ runs the bot using data found in the .env
+-- file with the @[CompiledPlugin]@ given. If you're looking to run the bot as
+-- detailed in the README (i.e. using data from .env), you should call this
+-- function.
 runTablebotWithEnv :: [CompiledPlugin] -> IO ()
 runTablebotWithEnv plugins = do
   -- fetch the version info as soon after building to reduce the likelihood that it changes between build and run

--- a/src/Tablebot.hs
+++ b/src/Tablebot.hs
@@ -137,7 +137,7 @@ runTablebot vinfo dToken prefix dbpath plugins config =
           updateStatusOptsGame =
             Just
               ( Activity
-                  { activityName = fromMaybe "with dice" (gamePlaying config) <> ". Prefix is `" <> prefix <> "`. Call `" <> prefix <> "help` for help",
+                  { activityName = gamePlaying config <> ". Prefix is `" <> prefix <> "`. Call `" <> prefix <> "help` for help",
                     activityType = ActivityTypeGame,
                     activityUrl = Nothing
                   }

--- a/src/Tablebot.hs
+++ b/src/Tablebot.hs
@@ -49,9 +49,6 @@ import Tablebot.Utility
 import Tablebot.Utility.Help
 import Text.Regex.PCRE ((=~))
 
--- TODO: Make a Config type or something which can be passed in to set various bits.
--- All plugins that rely on it can have that as an Env argument, found via MVar or similar.
-
 -- | runTablebotWithEnv @plugins@ runs the bot using data found in the .env
 -- file with the @[CompiledPlugin]@ given. If you're looking to run the bot as
 -- detailed in the README (i.e. using data from .env), you should call this
@@ -76,9 +73,12 @@ runTablebotWithEnv plugins config = do
     pure $ not (restartIsTerminal exit)
   putStrLn "Bot closed"
 
--- | runTablebot @dToken@ @prefix@ @dbpath@ @plugins@ @config@ runs the bot
--- using the given Discord API token @dToken@ and SQLite connection string
--- @dbpath@. Only the plugins provided by @plugins@ are run, and all commands
+-- | runTablebot @vinfo@ @dToken@ @prefix@ @dbpath@ @plugins@ @config@ runs the
+-- bot using the given Discord API token @dToken@ and SQLite connection string
+-- @dbpath@. In general, you should prefer @runTablebotWithEnv@ as it gets all
+-- of the required data for you, but this is exported for if you have weird
+-- setup requirements or don't want to use the administration plugin.
+-- Only the plugins provided by @plugins@ are run, and all commands
 -- are prefixed with @prefix@. @config@ details how the bot should present
 -- itself to users, allowing programmers to replace the Tablebot-specific text
 -- with their own.

--- a/src/Tablebot/Internal/Types.hs
+++ b/src/Tablebot/Internal/Types.hs
@@ -13,6 +13,7 @@ module Tablebot.Internal.Types where
 
 import Control.Concurrent.MVar (MVar)
 import Control.Monad.Reader (ReaderT)
+import Data.Default (Default)
 import Data.Text (Text)
 import Database.Persist.Sqlite (Migration, SqlPersistT)
 import Discord
@@ -81,3 +82,15 @@ data CompiledCronJob = CCronJob
   { timeframe :: Int,
     onCron :: CompiledDatabaseDiscord ()
   }
+
+-- * Configuration type
+
+-- Allows others to configure the bot.
+
+data BotConfig = BotConfig
+  { rootHelpText :: Maybe Text,
+    gamePlaying :: Maybe Text
+  }
+
+instance Default BotConfig where
+  def = BotConfig Nothing Nothing

--- a/src/Tablebot/Internal/Types.hs
+++ b/src/Tablebot/Internal/Types.hs
@@ -13,6 +13,7 @@ module Tablebot.Internal.Types where
 
 import Control.Concurrent.MVar (MVar)
 import Control.Monad.Reader (ReaderT)
+import Data.Default
 import Data.Text (Text)
 import Database.Persist.Sqlite (Migration, SqlPersistT)
 import Discord
@@ -90,3 +91,10 @@ data BotConfig = BotConfig
   { rootHelpText :: Text,
     gamePlaying :: Text
   }
+
+instance Default BotConfig where
+  def =
+    BotConfig
+      { rootHelpText = "This bot is built off the Tablebot framework (<https://github.com/WarwickTabletop/tablebot>).",
+        gamePlaying = "Kirby: Planet Robobot"
+      }

--- a/src/Tablebot/Internal/Types.hs
+++ b/src/Tablebot/Internal/Types.hs
@@ -13,7 +13,6 @@ module Tablebot.Internal.Types where
 
 import Control.Concurrent.MVar (MVar)
 import Control.Monad.Reader (ReaderT)
-import Data.Default (Default)
 import Data.Text (Text)
 import Database.Persist.Sqlite (Migration, SqlPersistT)
 import Discord
@@ -88,9 +87,6 @@ data CompiledCronJob = CCronJob
 -- Allows others to configure the bot.
 
 data BotConfig = BotConfig
-  { rootHelpText :: Maybe Text,
-    gamePlaying :: Maybe Text
+  { rootHelpText :: Text,
+    gamePlaying :: Text
   }
-
-instance Default BotConfig where
-  def = BotConfig Nothing Nothing

--- a/src/Tablebot/Plugins.hs
+++ b/src/Tablebot/Plugins.hs
@@ -9,51 +9,46 @@
 -- Here is a collection of existing plugins for Tablebot. If you add new plugins
 -- to the Plugins directory, include an import here. This means that users only
 -- need to import @Tablebot.Plugins@ to import individual plugins.
-module Tablebot.Plugins
-  ( plugins,
-  )
-where
+module Tablebot.Plugins where
 
 import Control.Concurrent.MVar (MVar)
 import Tablebot.Internal.Administration (ShutdownReason)
 import Tablebot.Internal.Plugins (compilePlugin)
 import Tablebot.Internal.Types (CompiledPlugin)
 import Tablebot.Plugins.Administration (administrationPlugin)
-import Tablebot.Plugins.Basic (basicPlugin)
-import Tablebot.Plugins.Cats (catPlugin)
-import Tablebot.Plugins.Dogs (dogPlugin)
-import Tablebot.Plugins.Flip (flipPlugin)
-import Tablebot.Plugins.Fox (foxPlugin)
-import Tablebot.Plugins.Netrunner (netrunnerPlugin)
-import Tablebot.Plugins.Ping (pingPlugin)
-import Tablebot.Plugins.Quote (quotePlugin)
-import Tablebot.Plugins.Reminder (reminderPlugin)
-import Tablebot.Plugins.Roll (rollPlugin)
-import Tablebot.Plugins.Say (sayPlugin)
-import Tablebot.Plugins.Shibe (shibePlugin)
-import Tablebot.Plugins.Suggest (suggestPlugin)
-import Tablebot.Plugins.Welcome (welcomePlugin)
+import Tablebot.Plugins.Basic (basic)
+import Tablebot.Plugins.Cats (cat)
+import Tablebot.Plugins.Dogs (dog)
+import Tablebot.Plugins.Flip (flips)
+import Tablebot.Plugins.Fox (fox)
+import Tablebot.Plugins.Netrunner (netrunner)
+import Tablebot.Plugins.Ping (pingpong)
+import Tablebot.Plugins.Quote (quotes)
+import Tablebot.Plugins.Reminder (reminder)
+import Tablebot.Plugins.Roll (roll)
+import Tablebot.Plugins.Say (says)
+import Tablebot.Plugins.Shibe (shibe)
+import Tablebot.Plugins.Suggest (suggests)
+import Tablebot.Plugins.Welcome (welcome)
 
 -- Use long list format to make additions and removals non-conflicting on git PRs
-plugins :: MVar ShutdownReason -> [CompiledPlugin]
-plugins rFlag =
-  addAdministrationPlugin
-    rFlag
-    [ compilePlugin pingPlugin,
-      compilePlugin basicPlugin,
-      compilePlugin catPlugin,
-      compilePlugin dogPlugin,
-      compilePlugin shibePlugin,
-      compilePlugin flipPlugin,
-      compilePlugin foxPlugin,
-      compilePlugin netrunnerPlugin,
-      compilePlugin quotePlugin,
-      compilePlugin reminderPlugin,
-      compilePlugin sayPlugin,
-      compilePlugin suggestPlugin,
-      compilePlugin rollPlugin,
-      compilePlugin welcomePlugin
-    ]
+allPlugins :: [CompiledPlugin]
+allPlugins =
+  [ pingpong,
+    basic,
+    cat,
+    dog,
+    shibe,
+    flips,
+    fox,
+    netrunner,
+    quotes,
+    reminder,
+    says,
+    suggests,
+    roll,
+    welcome
+  ]
 
 -- | @addAdministrationPlugin@ is needed to allow the administration plugin to be aware of the list of current plugins
 addAdministrationPlugin :: MVar ShutdownReason -> [CompiledPlugin] -> [CompiledPlugin]

--- a/src/Tablebot/Plugins/Basic.hs
+++ b/src/Tablebot/Plugins/Basic.hs
@@ -7,25 +7,13 @@
 -- Portability : POSIX
 --
 -- This is an example plugin which responds to certain calls with specific responses.
-module Tablebot.Plugins.Basic (basicPlugin) where
+module Tablebot.Plugins.Basic (basic) where
 
 import Data.Text as T (Text, toTitle)
-import Discord.Internal.Rest (Message)
+import Discord.Types (Message)
+import Tablebot.Utility
 import Tablebot.Utility.Discord (sendMessage)
 import Tablebot.Utility.SmartParser (parseComm)
-import Tablebot.Utility.Types
-  ( Command,
-    DatabaseDiscord,
-    EnvCommand (Command),
-    EnvInlineCommand (InlineCommand),
-    EnvPlugin (commands, inlineCommands),
-    HelpPage (HelpPage),
-    InlineCommand,
-    Plugin,
-    RequiredPermission (None),
-    helpPages,
-    plug,
-  )
 import Text.Megaparsec (anySingle, skipManyTill)
 import Text.Megaparsec.Char (string')
 
@@ -100,3 +88,6 @@ basicPlugin =
       helpPages = map baseHelp basicCommands,
       inlineCommands = map baseInlineCommand basicInlineCommands
     }
+
+basic :: CompiledPlugin
+basic = compilePlugin basicPlugin

--- a/src/Tablebot/Plugins/Cats.hs
+++ b/src/Tablebot/Plugins/Cats.hs
@@ -7,7 +7,7 @@
 -- Portability : POSIX
 --
 -- This is an example plugin which just responds with a cat photo to a .cat call
-module Tablebot.Plugins.Cats (catPlugin) where
+module Tablebot.Plugins.Cats (cat) where
 
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Aeson (FromJSON, Object, eitherDecode)
@@ -18,18 +18,9 @@ import GHC.Generics (Generic)
 import Network.HTTP.Conduit (Response (responseBody), parseRequest)
 import Network.HTTP.Simple (addRequestHeader, httpLBS)
 import System.Environment (lookupEnv)
+import Tablebot.Utility
 import Tablebot.Utility.Discord (Message, sendMessage)
 import Tablebot.Utility.SmartParser (parseComm)
-import Tablebot.Utility.Types
-  ( Command,
-    DatabaseDiscord,
-    EnvCommand (Command),
-    EnvPlugin (..),
-    HelpPage (HelpPage),
-    Plugin,
-    RequiredPermission (None),
-    plug,
-  )
 
 -- | @CatAPI@ is the basic data type for the JSON object that thecatapi returns
 data CatAPI = CatAPI
@@ -43,10 +34,10 @@ data CatAPI = CatAPI
 
 instance FromJSON CatAPI
 
--- | @cat@ is a command that takes no arguments (using 'noArguments') and
+-- | @catmmand@ is a command that takes no arguments (using 'noArguments') and
 -- replies with an image of a cat. Uses https://docs.thecatapi.com/ for cats.
-cat :: Command
-cat =
+catmmand :: Command
+catmmand =
   Command
     "cat"
     (parseComm sendCat)
@@ -87,4 +78,7 @@ catHelp = HelpPage "cat" [] "displays an image of a cat" "**Cat**\nGets a random
 
 -- | @catPlugin@ assembles these commands into a plugin containing cat
 catPlugin :: Plugin
-catPlugin = (plug "cats") {commands = [cat], helpPages = [catHelp]}
+catPlugin = (plug "cats") {commands = [catmmand], helpPages = [catHelp]}
+
+cat :: CompiledPlugin
+cat = compilePlugin catPlugin

--- a/src/Tablebot/Plugins/Cats.hs
+++ b/src/Tablebot/Plugins/Cats.hs
@@ -34,10 +34,10 @@ data CatAPI = CatAPI
 
 instance FromJSON CatAPI
 
--- | @catmmand@ is a command that takes no arguments (using 'noArguments') and
+-- | @catCommand@ is a command that takes no arguments (using 'noArguments') and
 -- replies with an image of a cat. Uses https://docs.thecatapi.com/ for cats.
-catmmand :: Command
-catmmand =
+catCommand :: Command
+catCommand =
   Command
     "cat"
     (parseComm sendCat)
@@ -78,7 +78,7 @@ catHelp = HelpPage "cat" [] "displays an image of a cat" "**Cat**\nGets a random
 
 -- | @catPlugin@ assembles these commands into a plugin containing cat
 catPlugin :: Plugin
-catPlugin = (plug "cats") {commands = [catmmand], helpPages = [catHelp]}
+catPlugin = (plug "cats") {commands = [catCommand], helpPages = [catHelp]}
 
 cat :: CompiledPlugin
 cat = compilePlugin catPlugin

--- a/src/Tablebot/Plugins/Dogs.hs
+++ b/src/Tablebot/Plugins/Dogs.hs
@@ -21,8 +21,8 @@ import Tablebot.Utility.SmartParser (parseComm)
 
 -- | @dog@ is a command that takes no arguments (using 'noArguments') and
 -- replies with an image of a dog. Uses https://randomdog.ca/ for dog images.
-dogmmand :: Command
-dogmmand =
+dogCommand :: Command
+dogCommand =
   Command
     "dog"
     (parseComm sendDog)
@@ -47,7 +47,7 @@ dogHelp = HelpPage "dog" [] "displays an image of a dog" "**Dog**\nGets a random
 
 -- | @dogPlugin@ assembles these commands into a plugin containing dog
 dogPlugin :: Plugin
-dogPlugin = (plug "dog") {commands = [dogmmand], helpPages = [dogHelp]}
+dogPlugin = (plug "dog") {commands = [dogCommand], helpPages = [dogHelp]}
 
 dog :: CompiledPlugin
 dog = compilePlugin dogPlugin

--- a/src/Tablebot/Plugins/Dogs.hs
+++ b/src/Tablebot/Plugins/Dogs.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveGeneric #-}
-
 -- |
 -- Module      : Tablebot.Plugins.Dog
 -- Description : A very simple plugin that provides dog pictures.
@@ -9,7 +7,7 @@
 -- Portability : POSIX
 --
 -- This is an example plugin which just responds with a dog photo to a .dog call
-module Tablebot.Plugins.Dogs (dogPlugin) where
+module Tablebot.Plugins.Dogs (dog) where
 
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Text (Text)
@@ -17,23 +15,14 @@ import Data.Text.Lazy (toStrict)
 import Data.Text.Lazy.Encoding (decodeUtf8)
 import Network.HTTP.Conduit (Response (responseBody), parseRequest)
 import Network.HTTP.Simple (httpLBS)
+import Tablebot.Utility
 import Tablebot.Utility.Discord (Message, sendMessage)
 import Tablebot.Utility.SmartParser (parseComm)
-import Tablebot.Utility.Types
-  ( Command,
-    DatabaseDiscord,
-    EnvCommand (Command),
-    EnvPlugin (..),
-    HelpPage (HelpPage),
-    Plugin,
-    RequiredPermission (None),
-    plug,
-  )
 
 -- | @dog@ is a command that takes no arguments (using 'noArguments') and
 -- replies with an image of a dog. Uses https://randomdog.ca/ for dog images.
-dog :: Command
-dog =
+dogmmand :: Command
+dogmmand =
   Command
     "dog"
     (parseComm sendDog)
@@ -58,4 +47,7 @@ dogHelp = HelpPage "dog" [] "displays an image of a dog" "**Dog**\nGets a random
 
 -- | @dogPlugin@ assembles these commands into a plugin containing dog
 dogPlugin :: Plugin
-dogPlugin = (plug "dog") {commands = [dog], helpPages = [dogHelp]}
+dogPlugin = (plug "dog") {commands = [dogmmand], helpPages = [dogHelp]}
+
+dog :: CompiledPlugin
+dog = compilePlugin dogPlugin

--- a/src/Tablebot/Plugins/Flip.hs
+++ b/src/Tablebot/Plugins/Flip.hs
@@ -7,7 +7,7 @@
 -- Portability : POSIX
 --
 -- A command that picks one random element from its given arguments.
-module Tablebot.Plugins.Flip (flipPlugin) where
+module Tablebot.Plugins.Flip (flips) where
 
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Text (pack)
@@ -51,3 +51,6 @@ Randomly picks one element from its arguments or, if none are provided, picks fr
 -- | @flipPlugin@ assembles the command into a plugin.
 flipPlugin :: Plugin
 flipPlugin = (plug "flip") {commands = [flip], helpPages = [flipHelp]}
+
+flips :: CompiledPlugin
+flips = compilePlugin flipPlugin

--- a/src/Tablebot/Plugins/Fox.hs
+++ b/src/Tablebot/Plugins/Fox.hs
@@ -33,8 +33,8 @@ instance FromJSON FoxAPI
 
 -- | @fox@ is a command that takes no arguments (using 'noArguments') and
 -- replies with an image of a fox. Uses https://randomfox.ca/ for fox images.
-foxmmand :: Command
-foxmmand =
+foxCommand :: Command
+foxCommand =
   Command
     "fox"
     (parseComm sendFox)
@@ -66,7 +66,7 @@ foxHelp = HelpPage "fox" [] "displays an image of a fox" "**Fox**\nGets a random
 
 -- | @foxPlugin@ assembles these commands into a plugin containing fox
 foxPlugin :: Plugin
-foxPlugin = (plug "fox") {commands = [foxmmand], helpPages = [foxHelp]}
+foxPlugin = (plug "fox") {commands = [foxCommand], helpPages = [foxHelp]}
 
 fox :: CompiledPlugin
 fox = compilePlugin foxPlugin

--- a/src/Tablebot/Plugins/Fox.hs
+++ b/src/Tablebot/Plugins/Fox.hs
@@ -9,27 +9,18 @@
 -- Portability : POSIX
 --
 -- This is an example plugin which just responds with a fox photo to a .fox call
-module Tablebot.Plugins.Fox (foxPlugin) where
+module Tablebot.Plugins.Fox (fox) where
 
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Aeson (FromJSON, eitherDecode)
 import Data.Functor ((<&>))
 import Data.Text (Text, pack)
-import GHC.Generics
+import GHC.Generics (Generic)
 import Network.HTTP.Conduit (Response (responseBody), parseRequest)
 import Network.HTTP.Simple (httpLBS)
+import Tablebot.Utility
 import Tablebot.Utility.Discord (Message, sendMessage)
 import Tablebot.Utility.SmartParser (parseComm)
-import Tablebot.Utility.Types
-  ( Command,
-    DatabaseDiscord,
-    EnvCommand (Command),
-    EnvPlugin (..),
-    HelpPage (HelpPage),
-    Plugin,
-    RequiredPermission (None),
-    plug,
-  )
 
 -- | @FoxAPI@ is the basic data type for the JSON object that the Fox API returns
 data FoxAPI = Fox
@@ -42,8 +33,8 @@ instance FromJSON FoxAPI
 
 -- | @fox@ is a command that takes no arguments (using 'noArguments') and
 -- replies with an image of a fox. Uses https://randomfox.ca/ for fox images.
-fox :: Command
-fox =
+foxmmand :: Command
+foxmmand =
   Command
     "fox"
     (parseComm sendFox)
@@ -75,4 +66,7 @@ foxHelp = HelpPage "fox" [] "displays an image of a fox" "**Fox**\nGets a random
 
 -- | @foxPlugin@ assembles these commands into a plugin containing fox
 foxPlugin :: Plugin
-foxPlugin = (plug "fox") {commands = [fox], helpPages = [foxHelp]}
+foxPlugin = (plug "fox") {commands = [foxmmand], helpPages = [foxHelp]}
+
+fox :: CompiledPlugin
+fox = compilePlugin foxPlugin

--- a/src/Tablebot/Plugins/Netrunner.hs
+++ b/src/Tablebot/Plugins/Netrunner.hs
@@ -7,6 +7,10 @@
 -- Portability : POSIX
 --
 -- Commands for interfacing with NetrunnerDB.
-module Tablebot.Plugins.Netrunner (netrunnerPlugin) where
+module Tablebot.Plugins.Netrunner (netrunner) where
 
 import Tablebot.Plugins.Netrunner.Plugin (netrunnerPlugin)
+import Tablebot.Utility (CompiledPlugin, compilePlugin)
+
+netrunner :: CompiledPlugin
+netrunner = compilePlugin netrunnerPlugin

--- a/src/Tablebot/Plugins/Netrunner/Utility/Card.hs
+++ b/src/Tablebot/Plugins/Netrunner/Utility/Card.hs
@@ -38,7 +38,6 @@ import Tablebot.Plugins.Netrunner.Utility.BanList (activeBanList, isBanned, isRe
 import Tablebot.Plugins.Netrunner.Utility.Misc (formatNr)
 import Tablebot.Utility
 import Tablebot.Utility.Types ()
-import Tablebot.Utility.Utils (intToText, maybeEmptyPrepend)
 
 -- | @toLink@ takes a card and generates a link to its NetrunnerDB page.
 toLink :: Card -> Text

--- a/src/Tablebot/Plugins/Ping.hs
+++ b/src/Tablebot/Plugins/Ping.hs
@@ -7,7 +7,7 @@
 -- Portability : POSIX
 --
 -- This is an example plugin which just responds "ping" to "!pong" and vice-versa.
-module Tablebot.Plugins.Ping (pingPlugin) where
+module Tablebot.Plugins.Ping (pingpong) where
 
 import Data.Text (Text)
 import Tablebot.Utility
@@ -49,3 +49,6 @@ pongHelp = HelpPage "pong" [] "show a more different debug message" "**Pong**\nS
 -- and pong.
 pingPlugin :: Plugin
 pingPlugin = (plug "ping") {commands = [ping, pong], helpPages = [pingHelp, pongHelp]}
+
+pingpong :: CompiledPlugin
+pingpong = compilePlugin pingPlugin

--- a/src/Tablebot/Plugins/Quote.hs
+++ b/src/Tablebot/Plugins/Quote.hs
@@ -10,7 +10,7 @@
 --
 -- This is an example plugin which allows user to @!quote add@ their favourite
 -- quotes and then @!quote show n@ a particular quote.
-module Tablebot.Plugins.Quote (quotePlugin) where
+module Tablebot.Plugins.Quote (quotes) where
 
 import Control.Monad (void)
 import Control.Monad.IO.Class (liftIO)
@@ -391,6 +391,9 @@ quotePlugin =
       migrations = [quoteMigration],
       helpPages = [quoteHelp]
     }
+
+quotes :: CompiledPlugin
+quotes = compilePlugin quotePlugin
 
 deriving instance Generic Quote
 

--- a/src/Tablebot/Plugins/Reminder.hs
+++ b/src/Tablebot/Plugins/Reminder.hs
@@ -10,10 +10,7 @@
 --
 -- This is an example plugin which allows user to ask the bot to remind them about
 -- something later in time.
-module Tablebot.Plugins.Reminder
-  ( reminderPlugin,
-  )
-where
+module Tablebot.Plugins.Reminder (reminder) where
 
 import Control.Monad (forM_)
 import Control.Monad.IO.Class (MonadIO (liftIO))
@@ -185,3 +182,6 @@ reminderPlugin =
       migrations = [reminderMigration],
       helpPages = [reminderHelp]
     }
+
+reminder :: CompiledPlugin
+reminder = compilePlugin reminderPlugin

--- a/src/Tablebot/Plugins/Roll.hs
+++ b/src/Tablebot/Plugins/Roll.hs
@@ -7,6 +7,10 @@
 -- Portability : POSIX
 --
 -- A command that outputs the result of rolling the input dice.
-module Tablebot.Plugins.Roll (rollPlugin) where
+module Tablebot.Plugins.Roll (roll) where
 
 import Tablebot.Plugins.Roll.Plugin (rollPlugin)
+import Tablebot.Utility
+
+roll :: CompiledPlugin
+roll = compilePlugin rollPlugin

--- a/src/Tablebot/Plugins/Say.hs
+++ b/src/Tablebot/Plugins/Say.hs
@@ -7,7 +7,7 @@
 -- Portability : POSIX
 --
 -- A command that outputs its input.
-module Tablebot.Plugins.Say (sayPlugin) where
+module Tablebot.Plugins.Say (says) where
 
 import Data.Text (pack)
 import Discord.Types (Message (messageAuthor), User (userId))
@@ -43,3 +43,6 @@ Repeat the input.
 -- | @sayPlugin@ assembles the command into a plugin.
 sayPlugin :: Plugin
 sayPlugin = (plug "say") {commands = [say], helpPages = [sayHelp]}
+
+says :: CompiledPlugin
+says = compilePlugin sayPlugin

--- a/src/Tablebot/Plugins/Shibe.hs
+++ b/src/Tablebot/Plugins/Shibe.hs
@@ -7,7 +7,7 @@
 -- Portability : POSIX
 --
 -- This is an example plugin which just responds with a shibe photo to a .shibe call
-module Tablebot.Plugins.Shibe (shibePlugin) where
+module Tablebot.Plugins.Shibe (shibe) where
 
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Aeson (eitherDecode)
@@ -15,27 +15,17 @@ import Data.Functor ((<&>))
 import Data.Text (Text, pack)
 import Network.HTTP.Conduit (Response (responseBody), parseRequest)
 import Network.HTTP.Simple (httpLBS)
+import Tablebot.Utility
 import Tablebot.Utility.Discord (Message, sendMessage)
 import Tablebot.Utility.SmartParser (parseComm)
-import Tablebot.Utility.Types
-  ( Command,
-    DatabaseDiscord,
-    EnvCommand (Command),
-    EnvPlugin (..),
-    HelpPage (HelpPage),
-    Plugin,
-    RequiredPermission (None),
-    commandAlias,
-    plug,
-  )
 
 -- | @ShibeAPI@ is the basic data type for the JSON object that the Shibe API returns
 type ShibeAPI = Text
 
 -- | @shibe@ is a command that takes no arguments (using 'noArguments') and
 -- replies with an image of a shibe. Uses https://shibe.online/ for shibe images.
-shibe :: Command
-shibe =
+shibes :: Command
+shibes =
   Command
     "shibe"
     (parseComm sendShibe)
@@ -105,4 +95,7 @@ birbHelp = HelpPage "bird" [] "displays an image of a bird" "**Bird**\nGets a ra
 
 -- | @shibePlugin@ assembles these commands into a plugin containing shibe
 shibePlugin :: Plugin
-shibePlugin = (plug "shibe") {commands = [birb, commandAlias "bird" birb, shibe], helpPages = [birbHelp, shibeHelp]}
+shibePlugin = (plug "shibe") {commands = [birb, commandAlias "bird" birb, shibes], helpPages = [birbHelp, shibeHelp]}
+
+shibe :: CompiledPlugin
+shibe = compilePlugin shibePlugin

--- a/src/Tablebot/Plugins/Suggest.hs
+++ b/src/Tablebot/Plugins/Suggest.hs
@@ -7,7 +7,7 @@
 -- Portability : POSIX
 --
 -- A command that shows the link for a user to suggest a new game to buy.
-module Tablebot.Plugins.Suggest (suggestPlugin) where
+module Tablebot.Plugins.Suggest (suggests) where
 
 import Data.Text (pack)
 import Tablebot.Utility
@@ -38,3 +38,6 @@ suggestHelp = HelpPage "suggest" [] "show links to suggest a new game for the so
 
 suggestPlugin :: Plugin
 suggestPlugin = (plug "suggest") {commands = [suggest], helpPages = [suggestHelp]}
+
+suggests :: CompiledPlugin
+suggests = compilePlugin suggestPlugin

--- a/src/Tablebot/Plugins/Welcome.hs
+++ b/src/Tablebot/Plugins/Welcome.hs
@@ -7,7 +7,7 @@
 -- Portability : POSIX
 --
 -- Commands for generating welcome messages.
-module Tablebot.Plugins.Welcome (welcomePlugin) where
+module Tablebot.Plugins.Welcome (welcome) where
 
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Reader (ask)
@@ -101,3 +101,6 @@ welcomeStartUp = StartUp $ liftIO readCategories
 -- | @welcomePlugin@ assembles these commands into a plugin.
 welcomePlugin :: EnvPlugin SS
 welcomePlugin = (envPlug "welcome" welcomeStartUp) {commands = [favourite], helpPages = [favouriteHelp]}
+
+welcome :: CompiledPlugin
+welcome = compilePlugin welcomePlugin

--- a/src/Tablebot/Utility.hs
+++ b/src/Tablebot/Utility.hs
@@ -12,8 +12,12 @@
 module Tablebot.Utility
   ( module Types,
     module Utils,
+    compilePlugin,
+    CompiledPlugin,
   )
 where
 
+import Tablebot.Internal.Plugins (compilePlugin)
+import Tablebot.Internal.Types (CompiledPlugin)
 import Tablebot.Utility.Types as Types hiding (Pl)
 import Tablebot.Utility.Utils as Utils

--- a/src/Tablebot/Utility/Help.hs
+++ b/src/Tablebot/Utility/Help.hs
@@ -10,6 +10,7 @@
 module Tablebot.Utility.Help where
 
 import Data.Functor (($>))
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Tablebot.Internal.Permission (getSenderPermission, userHasPermission)
@@ -30,16 +31,16 @@ rootBody =
 helpHelpPage :: HelpPage
 helpHelpPage = HelpPage "help" [] "show information about commands" "**Help**\nShows information about bot commands\n\n*Usage:* `help <page>`" [] None
 
-generateHelp :: CombinedPlugin -> CombinedPlugin
-generateHelp p =
+generateHelp :: Maybe Text -> CombinedPlugin -> CombinedPlugin
+generateHelp rootText p =
   p
-    { combinedSetupAction = return (PA [CCommand "help" (handleHelp (helpHelpPage : combinedHelpPages p)) []] [] [] [] [] [] []) : combinedSetupAction p
+    { combinedSetupAction = return (PA [CCommand "help" (handleHelp rootText (helpHelpPage : combinedHelpPages p)) []] [] [] [] [] [] []) : combinedSetupAction p
     }
 
-handleHelp :: [HelpPage] -> Parser (Message -> CompiledDatabaseDiscord ())
-handleHelp hp = parseHelpPage root
+handleHelp :: Maybe Text -> [HelpPage] -> Parser (Message -> CompiledDatabaseDiscord ())
+handleHelp rootText hp = parseHelpPage root
   where
-    root = HelpPage "" [] "" rootBody hp None
+    root = HelpPage "" [] "" (fromMaybe rootBody rootText) hp None
 
 parseHelpPage :: HelpPage -> Parser (Message -> CompiledDatabaseDiscord ())
 parseHelpPage hp = do

--- a/src/Tablebot/Utility/Help.hs
+++ b/src/Tablebot/Utility/Help.hs
@@ -10,7 +10,6 @@
 module Tablebot.Utility.Help where
 
 import Data.Functor (($>))
-import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Tablebot.Internal.Permission (getSenderPermission, userHasPermission)
@@ -22,25 +21,19 @@ import Tablebot.Utility.Permission (requirePermission)
 import Tablebot.Utility.Types hiding (helpPages)
 import Text.Megaparsec (choice, chunk, eof, try, (<?>), (<|>))
 
-rootBody :: Text
-rootBody =
-  "**Tabletop Bot**\n\
-  \This friendly little bot provides several tools to help with\
-  \ the running of the Warwick Tabletop Games and Role-Playing Society Discord server."
-
 helpHelpPage :: HelpPage
 helpHelpPage = HelpPage "help" [] "show information about commands" "**Help**\nShows information about bot commands\n\n*Usage:* `help <page>`" [] None
 
-generateHelp :: Maybe Text -> CombinedPlugin -> CombinedPlugin
+generateHelp :: Text -> CombinedPlugin -> CombinedPlugin
 generateHelp rootText p =
   p
     { combinedSetupAction = return (PA [CCommand "help" (handleHelp rootText (helpHelpPage : combinedHelpPages p)) []] [] [] [] [] [] []) : combinedSetupAction p
     }
 
-handleHelp :: Maybe Text -> [HelpPage] -> Parser (Message -> CompiledDatabaseDiscord ())
+handleHelp :: Text -> [HelpPage] -> Parser (Message -> CompiledDatabaseDiscord ())
 handleHelp rootText hp = parseHelpPage root
   where
-    root = HelpPage "" [] "" (fromMaybe rootBody rootText) hp None
+    root = HelpPage "" [] "" rootText hp None
 
 parseHelpPage :: HelpPage -> Parser (Message -> CompiledDatabaseDiscord ())
 parseHelpPage hp = do


### PR DESCRIPTION
* Moved the botcontrol implementation (which allows the bot to restart when asked) into `Tablebot` as `runTablebotWithEnv` rather than having it in `app/Main.hs`. `runTablebotWithEnv` allows the plugins you want to be used to be specified.
* Changed every Plugin directory to export a `CompiledPlugin` rather than a `Plugin`, avoiding the need for users to compile their own plugins.
* Added `BotConfig`, which allows you to specify a few bits of user-facing text to fit your bot.