### PR TITLE
Alias

### DIFF
--- a/src/Tablebot/Internal/Alias.hs
+++ b/src/Tablebot/Internal/Alias.hs
@@ -1,0 +1,37 @@
+-- |
+-- Module      : Tablebot.Internal.Alias
+-- Description : Alias management
+-- License     : MIT
+-- Maintainer  : tagarople@gmail.com
+-- Stability   : experimental
+-- Portability : POSIX
+--
+-- Alias management
+module Tablebot.Internal.Alias where
+
+import Control.Monad.Exception (MonadException (catch), SomeException)
+import Data.Text (Text)
+import Database.Persist.Sqlite (BackendKey (SqlBackendKey))
+import qualified Database.Persist.Sqlite as Sql
+import Database.Persist.TH
+import Discord.Types (UserId)
+import Tablebot.Internal.Types (AliasType (..))
+import Tablebot.Utility.Database (selectList)
+import Tablebot.Utility.Types (EnvDatabaseDiscord)
+
+share
+  [mkPersist sqlSettings, mkMigrate "aliasMigration"]
+  [persistLowerCase|
+Alias
+    alias Text
+    command Text
+    type AliasType
+    UniqueAlias alias type
+    deriving Show
+    deriving Eq
+|]
+
+getAliases :: UserId -> EnvDatabaseDiscord d (Maybe [Alias])
+getAliases uid =
+  (Just . fmap Sql.entityVal <$> selectList [AliasType Sql.<-. [AliasPublic, AliasPrivate uid]] [])
+    `catch` (\(_ :: SomeException) -> return Nothing)

--- a/src/Tablebot/Internal/Handler/Command.hs
+++ b/src/Tablebot/Internal/Handler/Command.hs
@@ -16,12 +16,15 @@ module Tablebot.Internal.Handler.Command
   )
 where
 
+import Data.List (find)
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe (catMaybes)
 import Data.Set (singleton, toList)
 import Data.Text (Text)
+import qualified Data.Text as T
 import Data.Void (Void)
-import Discord.Types (Message (messageText))
+import Discord.Types (Message (messageAuthor, messageText), User (userId))
+import Tablebot.Internal.Alias (Alias (aliasAlias, aliasCommand), getAliases)
 import Tablebot.Internal.Plugins (changeAction)
 import Tablebot.Internal.Types
 import Tablebot.Utility.Discord (sendEmbedMessage)
@@ -49,6 +52,14 @@ parseNewMessage pl prefix m =
     checkCommand :: Parser ()
     checkCommand = chunk prefix *> word *> (space <|> eof)
 
+parseCommands :: [CompiledCommand] -> Message -> Text -> CompiledDatabaseDiscord ()
+parseCommands cs m prefix = do
+  as <- changeAction () $ getAliases (userId $ messageAuthor m)
+  res <- parseCommands' cs as m prefix
+  case res of
+    Right _ -> return ()
+    Left (title, e) -> changeAction () . sendEmbedMessage m "" $ embedError $ ParserException (T.unpack title) . T.unpack $ "```\n" <> e <> "```"
+
 -- | Given a list of 'Command' @cs@, the 'Message' that triggered the event
 -- @m@, and a command prefix @prefix@, construct a parser that parses commands.
 -- We look for the prefix, followed by trying out the name of each command,
@@ -57,13 +68,29 @@ parseNewMessage pl prefix m =
 --
 -- If the parser errors, the last error (which is hopefully one created by
 -- '<?>') is sent to the user as a Discord message.
-parseCommands :: [CompiledCommand] -> Message -> Text -> CompiledDatabaseDiscord ()
-parseCommands cs m prefix = case parse (parser cs) "" (messageText m) of
-  Right p -> p m
-  Left e ->
-    let (errs, title) = makeBundleReadable e
-     in changeAction () . sendEmbedMessage m "" $ embedError $ ParserException title $ "```\n" ++ errorBundlePretty errs ++ "```"
+parseCommands' :: [CompiledCommand] -> Maybe [Alias] -> Message -> Text -> CompiledDatabaseDiscord (Either (Text, Text) ())
+parseCommands' cs as m prefix = case parse (parser cs) "" (messageText m) of
+  Right p -> Right <$> p m
+  Left e -> case as of
+    (Just as'@(_ : _)) ->
+      case parse (aliasParser as') "" (messageText m) of
+        -- if the alias parser fails, just give the outer error
+        Left _ -> mkTitleBody e
+        -- if we get a valid alias, run the command with the alias
+        -- the way we do this is by running this function again and edit the
+        -- message text to be the alias's command
+        -- we ensure no infinite loops by removing the alias we just used
+        Right (a', rest) -> do
+          recur <- parseCommands' cs (Just $ filter (/= a') as') (m {messageText = prefix <> aliasCommand a' <> rest}) prefix
+          -- if successful, return the result. if not, edit the error we
+          -- obtained from running the alias to include the alias we tried to
+          -- use
+          case recur of
+            Right _ -> return recur
+            Left (title, err) -> return $ Left (title, aliasAlias a' <> " -> " <> aliasCommand a' <> "\n" <> err)
+    _ -> mkTitleBody e
   where
+    mkTitleBody e' = let (errs, title) = makeBundleReadable e' in return $ Left (T.pack title, T.pack $ errorBundlePretty errs)
     parser :: [CompiledCommand] -> Parser (Message -> CompiledDatabaseDiscord ())
     parser cs' =
       do
@@ -71,6 +98,14 @@ parseCommands cs m prefix = case parse (parser cs) "" (messageText m) of
         choice (map toErroringParser cs') <?> "No command with that name was found!"
     toErroringParser :: CompiledCommand -> Parser (Message -> CompiledDatabaseDiscord ())
     toErroringParser c = try (chunk $ commandName c) *> (skipSpace1 <|> eof) *> (try (choice $ map toErroringParser $ commandSubcommands c) <|> commandParser c)
+    aliasParser :: [Alias] -> Parser (Alias, Text)
+    aliasParser as' = do
+      _ <- chunk prefix
+      a <- choice (map (chunk . aliasAlias) as') <?> "No command with that name was found!"
+      rst <- many anySingle
+      case find (\a' -> aliasAlias a' == a) as' of
+        Just a' -> return (a', T.pack rst)
+        Nothing -> fail "This should never happen! (aliasParser)"
 
 data ReadableError = UnknownError | KnownError String [String]
   deriving (Show, Eq, Ord)

--- a/src/Tablebot/Plugins.hs
+++ b/src/Tablebot/Plugins.hs
@@ -19,6 +19,7 @@ import Tablebot.Internal.Administration (ShutdownReason)
 import Tablebot.Internal.Plugins (compilePlugin)
 import Tablebot.Internal.Types (CompiledPlugin)
 import Tablebot.Plugins.Administration (administrationPlugin)
+import Tablebot.Plugins.Alias (aliasPlugin)
 import Tablebot.Plugins.Basic (basicPlugin)
 import Tablebot.Plugins.Cats (catPlugin)
 import Tablebot.Plugins.Dogs (dogPlugin)
@@ -40,6 +41,7 @@ plugins rFlag =
   addAdministrationPlugin
     rFlag
     [ compilePlugin pingPlugin,
+      compilePlugin aliasPlugin,
       compilePlugin basicPlugin,
       compilePlugin catPlugin,
       compilePlugin dogPlugin,

--- a/src/Tablebot/Plugins/Alias.hs
+++ b/src/Tablebot/Plugins/Alias.hs
@@ -191,10 +191,3 @@ Deletes a private alias.
       HelpPage "public" [] "deletes a public alias" "**Delete Public Alias**\nDeletes a public alias.\n\n*Usage:* `alias delete public <alias>`" [] publicAliasPerms
     ]
     None
-
-{-
-You can specify whether the alias to delete is public or private.
-Public aliases can only be deleted by moderators.
-
-, `alias delete private <alias>`, `alias delete public <alias>`
--}

--- a/src/Tablebot/Plugins/Alias.hs
+++ b/src/Tablebot/Plugins/Alias.hs
@@ -1,0 +1,158 @@
+module Tablebot.Plugins.Alias (aliasPlugin) where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Database.Persist.Sqlite as Sql
+import Discord.Types (Message (messageAuthor), User (userId))
+import Tablebot.Internal.Alias
+import Tablebot.Internal.Types (AliasType (..))
+import Tablebot.Utility
+import Tablebot.Utility.Database (deleteBy, exists)
+import Tablebot.Utility.Discord (sendMessage)
+import Tablebot.Utility.Permission (requirePermission)
+import Tablebot.Utility.SmartParser (PComm (parseComm), Quoted (..), WithError (..))
+import Text.RawString.QQ (r)
+
+aliasTypeToText :: AliasType -> Text
+aliasTypeToText AliasPublic = "Public"
+aliasTypeToText (AliasPrivate _) = "Private"
+
+updateAlias :: Alias -> EnvDatabaseDiscord d (Sql.Entity Alias)
+updateAlias alias = liftSql $ Sql.upsertBy (UniqueAlias (aliasAlias alias) (aliasType alias)) alias [AliasCommand Sql.=. aliasCommand alias]
+
+aliasPlugin :: Plugin
+aliasPlugin =
+  (plug "alias")
+    { commands = [aliasComm],
+      migrations = [aliasMigration],
+      helpPages = [aliasHelp]
+    }
+
+aliasComm :: Command
+aliasComm =
+  Command
+    "alias"
+    (parseComm (\m -> aliasList (AliasPrivate (userId $ messageAuthor m)) m))
+    [aliasAddCommand, aliasListCommand, aliasDeleteCommand]
+
+aliasHelp :: HelpPage
+aliasHelp =
+  HelpPage
+    "alias"
+    []
+    "alias a command to another command"
+    [r|**Aliases**
+Allows creation, viewing, and deletion of aliases.
+Calling without any arguments will show a list of aliases. 
+
+*Usage:* `alias`|]
+    [aliasAddHelp, aliasListHelp, aliasDeleteHelp]
+    None
+
+aliasAddCommand :: Command
+aliasAddCommand =
+  Command
+    "add"
+    (parseComm aliasAddPrivateComm)
+    [ Command "private" (parseComm aliasAddPrivateComm) [],
+      Command "public" (parseComm aliasAddPublicComm) []
+    ]
+  where
+    aliasAddPrivateComm :: WithError "Need a single word" Text -> WithError "Need a quoted string" (Quoted Text) -> Message -> DatabaseDiscord ()
+    aliasAddPrivateComm (WErr t) (WErr (Qu t')) m = aliasAdd t t' (AliasPrivate (userId $ messageAuthor m)) m
+    aliasAddPublicComm :: WithError "Need a single word" Text -> WithError "Need a quoted string" (Quoted Text) -> Message -> DatabaseDiscord ()
+    aliasAddPublicComm (WErr t) (WErr (Qu t')) m = requirePermission Moderator m $ aliasAdd t t' AliasPublic m
+
+aliasAdd :: Text -> Text -> AliasType -> Message -> DatabaseDiscord ()
+aliasAdd a b at m = do
+  let new = Alias a b at
+  _ <- updateAlias new
+  sendMessage m ("Added " <> T.toLower (aliasTypeToText at) <> " alias `" <> a <> "` -> `" <> b <> "`")
+
+aliasAddHelp :: HelpPage
+aliasAddHelp =
+  HelpPage
+    "add"
+    []
+    "adds an alias"
+    [r|**Add Alias**
+Adds an alias.
+You can specify whether the alias is public or private.
+Public aliases can only be added by moderators.
+
+*Usage:* `alias add <alias> "<command>"`, `alias add private <alias> "<command>"` , `alias add public <alias> "<command>"`|]
+    []
+    None
+
+aliasListCommand :: Command
+aliasListCommand =
+  Command
+    "list"
+    (parseComm aliasListPrivateComm)
+    [ Command "private" (parseComm aliasListPrivateComm) [],
+      Command "public" (parseComm aliasListPublicComm) []
+    ]
+  where
+    aliasListPrivateComm :: Message -> DatabaseDiscord ()
+    aliasListPrivateComm m = aliasList (AliasPrivate (userId $ messageAuthor m)) m
+    aliasListPublicComm :: Message -> DatabaseDiscord ()
+    aliasListPublicComm m = aliasList AliasPublic m
+
+aliasList :: AliasType -> Message -> DatabaseDiscord ()
+aliasList at m = do
+  aliases <- fmap Sql.entityVal <$> liftSql (Sql.selectList [AliasType Sql.==. at] [])
+  let msg =
+        aliasTypeToText at <> " aliases:\n"
+          <> T.unlines (map (\(Alias a b _) -> "\t`" <> a <> "` -> `" <> b <> "`") aliases)
+  sendMessage m msg
+
+aliasListHelp :: HelpPage
+aliasListHelp =
+  HelpPage
+    "list"
+    []
+    "lists aliases"
+    [r|**List Aliases**
+Lists all aliases.
+You can specify whether the aliases are public or private.
+
+*Usage:* `alias list`, `alias list private`, `alias list public`|]
+    []
+    None
+
+aliasDeleteCommand :: Command
+aliasDeleteCommand =
+  Command
+    "delete"
+    (parseComm aliasDeletePrivateComm)
+    [ Command "private" (parseComm aliasDeletePrivateComm) [],
+      Command "public" (parseComm aliasDeletePublicComm) []
+    ]
+  where
+    aliasDeletePrivateComm :: WithError "Need a single word" Text -> Message -> DatabaseDiscord ()
+    aliasDeletePrivateComm (WErr t) m = aliasDelete t (AliasPrivate (userId $ messageAuthor m)) m
+    aliasDeletePublicComm :: WithError "Need a single word" Text -> Message -> DatabaseDiscord ()
+    aliasDeletePublicComm (WErr t) m = requirePermission Moderator m $ aliasDelete t AliasPublic m
+
+aliasDelete :: Text -> AliasType -> Message -> DatabaseDiscord ()
+aliasDelete a at m = do
+  let toDelete = UniqueAlias a at
+  itemExists <- exists [AliasAlias Sql.==. a, AliasType Sql.==. at]
+  if itemExists
+    then deleteBy toDelete >> sendMessage m ("Deleted alias `" <> a <> "`")
+    else sendMessage m ("No such alias `" <> a <> "`")
+
+aliasDeleteHelp :: HelpPage
+aliasDeleteHelp =
+  HelpPage
+    "delete"
+    []
+    "deletes an alias"
+    [r|**Delete Alias**
+Deletes an alias.
+You can specify whether the alias to delete is public or private.
+Public aliases can only be deleted by moderators.
+
+*Usage:* `alias delete <alias>`, `alias delete private <alias>`, `alias delete public <alias>`|]
+    []
+    None


### PR DESCRIPTION
Commands and guts to alias a word to another operation, with two levels of aliases (public and private).
for example, `$alias add private honour "roll 8d6 'for honour'"` adds an a private alias `honour` which only the user of the command can use which calls `roll 8d6 'for honour'`.

Public aliases can only be added and deleted by moderators. People can view their own aliases as well as public ones using `$alias list private` and `$alias list public` respectively.

Aliases can refer to each other, but each one can only be activated once.

Another example: `$alias add public advantage "roll 2d20kh1"` creates an alias that allows you to roll with advantage.

![image](https://user-images.githubusercontent.com/10566848/162071163-f3020bc4-ee47-4090-b0d3-63fa13faef21.png)
