### PR TITLE
Add Dockerfile 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-      - uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v2
 
       - name: Build and Push Docker image
         uses: docker/build-push-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
@@ -17,26 +17,38 @@ jobs:
   ormolu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: mrkkrp/ormolu-action@v4
+
   build:
-    name: Build
-    runs-on: ubuntu-latest # or macOS-latest, or windows-latest
-    needs: ormolu
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    needs:
+      - ormolu
+    if: success()
     steps:
-      - uses: actions/checkout@v2
-      - uses: haskell/actions/setup@v1
+      - uses: actions/checkout@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        if: github.ref_name == 'main' && github.event_name == 'push' # don't need to login if we're not pushing
         with:
-          ghc-version: 'latest'
-          enable-stack: true
-          stack-version: 'latest'
-      - name: Cache .stack
-        id: cache-stack
-        uses: actions/cache@v2
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get short commit hash
+        id: hash
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
         with:
-          path: ~/.stack
-          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml') }}
-          restore-keys: |
-              ${{ runner.os }}-stack
-              ${{ runner.os }}
-      - run: stack build
+          context: .
+          push: github.ref_name == 'main' && github.event_name == 'push' # only actually publish on push to main
+          tags: |
+            "ghcr.io/${{ github.repository_owner }}/tablebot:latest"
+            "ghcr.io/${{ github.repository_owner }}/tablebot:${{ steps.hash.outputs.sha_short }}"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,10 @@ jobs:
         id: hash
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Build and push Docker image
+      - name: Set up Docker Buildx
+      - uses: docker/setup-buildx-action@v2
+
+      - name: Build and Push Docker image
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: github.ref_name == 'main' && github.event_name == 'push' # only actually publish on push to main
+          push: ${{ github.ref_name == 'main' && github.event_name == 'push' }} # only actually publish on push to main
           tags: |
             "ghcr.io/${{ github.repository_owner }}/tablebot:latest"
             "ghcr.io/${{ github.repository_owner }}/tablebot:${{ steps.hash.outputs.sha_short }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }} # dont push on a pull request
-          tags: |
-            "ghcr.io/${{ github.repository_owner }}/tablebot:latest"
-            "ghcr.io/${{ github.repository_owner }}/tablebot:${{ steps.hash.outputs.sha_short }}"
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
-        if: github.ref_name == 'main' && github.event_name == 'push' # don't need to login if we're not pushing
+        if: github.event_name != 'pull_request' # don't need to login if we're not pushing
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,9 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}
-          tags: type=sha
+          tags: | # tag with commit hash and with 'latest'
+            type=sha 
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
     if: success()
     steps:
       - uses: actions/checkout@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         if: github.ref_name == 'main' && github.event_name == 'push' # don't need to login if we're not pushing
@@ -38,9 +39,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get short commit hash
-        id: hash
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Get Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: type=sha
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -49,7 +53,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: ${{ github.ref_name == 'main' && github.event_name == 'push' }} # only actually publish on push to main
+          push: ${{ github.event_name != 'pull_request' }} # dont push on a pull request
           tags: |
             "ghcr.io/${{ github.repository_owner }}/tablebot:latest"
             "ghcr.io/${{ github.repository_owner }}/tablebot:${{ steps.hash.outputs.sha_short }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# stack resolver 18.18 uses ghc 8.10.7
+FROM haskell:8.10.7 as build
+RUN mkdir -p /tablebot/build
+WORKDIR /tablebot/build
+
+# system lib dependencies
+RUN apt-get update -qq && \
+  apt-get install -qq -y libpcre3-dev build-essential pkg-config libicu-dev --fix-missing --no-install-recommends && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY . . 
+
+RUN stack build --system-ghc
+
+RUN mv "$(stack path --local-install-root --system-ghc)/bin" /tablebot/build/bin
+
+FROM haskell:8.10.7-slim as app
+
+# system runtime deps
+RUN apt-get update -qq && \
+  apt-get install -qq -y libpcre3 libicu63 --fix-missing --no-install-recommends && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN mkdir -p /tablebot
+WORKDIR /tablebot
+
+COPY --from=build /tablebot/build/bin .
+# apparently we need the .git folder
+COPY .git .git 
+CMD /tablebot/tablebot-exe


### PR DESCRIPTION
This PR adds a Dockerfile for building a container image of tablebot.

I've also modified the CI workflow to build tablebot within docker instead of straight on the actions runner. The workflow will then publish the docker image to ghcr if the workflow is triggered by not a pull request (a push to the main branch).

This will allow for more streamlined deployment of tablebot on the new UWCS infrastructure.

The container image is a bit large (1.7GB) as I've not hyper-optimised the build. I can put some more time into it if you need, or can save for a later date.