### PR TITLE
Massively improve Dice Stats performance

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,7 +3,7 @@ packages: .
 source-repository-package
   type: git
   location: git@github.com:L0neGamer/haskell-distribution.git
-  tag: 569d6452e4bffedb2c0d3795885fccdb22a4d29d
+  tag: 313eb7a280b010fda1e21876da4171503c76516f
 
 source-repository-package
   type: git

--- a/package.yaml
+++ b/package.yaml
@@ -126,3 +126,12 @@ tests:
       - -with-rtsopts=-N
     dependencies:
       - tablebot
+      - tasty
+      - tasty-discover
+      - tasty-hspec
+      - tasty-hedgehog
+      - hspec
+      - hedgehog
+      - hspec-hedgehog
+    build-tools:
+      - tasty-discover:tasty-discover

--- a/package.yaml
+++ b/package.yaml
@@ -112,6 +112,7 @@ executables:
     ghc-options:
       - -threaded
       - -rtsopts
+      - -Wall
       - "\"-with-rtsopts=-Iw10 -N\""
     dependencies:
       - tablebot
@@ -124,6 +125,7 @@ tests:
       - -threaded
       - -rtsopts
       - -with-rtsopts=-N
+      - -Wall
     dependencies:
       - tablebot
       - tasty

--- a/src/Tablebot/Plugins/Roll/Dice.hs
+++ b/src/Tablebot/Plugins/Roll/Dice.hs
@@ -83,7 +83,8 @@ module Tablebot.Plugins.Roll.Dice (evalProgram, evalInteger, evalList, ListValue
 
 import Tablebot.Plugins.Roll.Dice.DiceData
   ( Converter (promote),
-    Die (Die),
+    Die (..),
+    DieOf (..),
     Expr,
     ListValues (..),
     NumBase (Value),
@@ -94,4 +95,4 @@ import Tablebot.Plugins.Roll.Dice.DiceParsing ()
 
 -- | The default expression to evaluate if no expression is given.
 defaultRoll :: Expr
-defaultRoll = promote (Die (Value 20))
+defaultRoll = promote (MkDie (Die (Value 20)))

--- a/src/Tablebot/Plugins/Roll/Dice/DiceData.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceData.hs
@@ -147,12 +147,14 @@ data DieOf (l :: Laziness) where
   LazyDie :: DieOf Strict -> DieOf Lazy
 
 deriving instance Show (DieOf l)
+
 deriving instance Eq (DieOf l)
 
 data Die where
   MkDie :: DieOf l -> Die
 
 deriving instance Show Die
+
 instance Eq Die where
   (==) (MkDie die1) (MkDie die2) = case (die1, die2) of
     (Die n1, Die n2) -> n1 == n2
@@ -192,18 +194,21 @@ advancedOrderingMapping = (M.fromList lst, M.fromList $ swap <$> lst)
 -- | The type representing a die option; a reroll, a keep/drop operation, or
 -- lazily performing some other die option.
 data DieOpOptionOf (l :: Laziness) where
-  Reroll :: {rerollOnce :: Bool, condition :: AdvancedOrdering, limit :: NumBase}
-    -> DieOpOptionOf l
+  Reroll ::
+    {rerollOnce :: Bool, condition :: AdvancedOrdering, limit :: NumBase} ->
+    DieOpOptionOf l
   DieOpOptionKD :: KeepDrop -> LowHighWhere -> DieOpOptionOf l
   DieOpOptionLazy :: DieOpOptionOf Strict -> DieOpOptionOf Lazy
 
 deriving instance Show (DieOpOptionOf l)
+
 deriving instance Eq (DieOpOptionOf l)
 
 data DieOpOption where
   MkDieOpOption :: DieOpOptionOf l -> DieOpOption
 
 deriving instance Show DieOpOption
+
 instance Eq DieOpOption where
   (==) (MkDieOpOption doo1) (MkDieOpOption doo2) = case (doo1, doo2) of
     (Reroll rro1 cond1 lim1, Reroll rro2 cond2 lim2) ->

--- a/src/Tablebot/Plugins/Roll/Dice/DiceData.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceData.hs
@@ -72,7 +72,7 @@ data ListValuesBase = LVBParen (Paren ListValues) | LVBList [Expr]
 
 -- | The type for a binary operator between one or more `sub` values
 data BinOp sub typ where
-  BinOp :: (Operation typ) => sub -> [(typ, sub)] -> BinOp sub typ
+  BinOp :: sub -> [(typ, sub)] -> BinOp sub typ
 
 deriving instance (Show sub, Show typ) => Show (BinOp sub typ)
 

--- a/src/Tablebot/Plugins/Roll/Dice/DiceData.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceData.hs
@@ -212,20 +212,22 @@ instance Eq DieOpOption where
     (DieOpOptionLazy dooo1, DieOpOptionLazy dooo2) -> dooo1 == dooo2
     _ -> False
 
+data LowHigh = Low | High
+  deriving (Show, Eq, Enum, Bounded)
+
 -- | A type used to designate how the keep/drop option should work
-data LowHighWhere = Low NumBase | High NumBase | Where AdvancedOrdering NumBase deriving (Show, Eq)
+data LowHighWhere = LH LowHigh NumBase | Where AdvancedOrdering NumBase deriving (Show, Eq)
 
 -- | Utility function to get the integer determining how many values to get
 -- given a `LowHighWhere`. If the given value is `Low` or `High`, then Just the
 -- NumBase contained is returned. Else, Nothing is returned.
 getValueLowHigh :: LowHighWhere -> Maybe NumBase
-getValueLowHigh (Low i) = Just i
-getValueLowHigh (High i) = Just i
+getValueLowHigh (LH _ i) = Just i
 getValueLowHigh (Where _ _) = Nothing
 
 -- | Returns whether the given `LowHighWhere` is `Low` or not.
 isLow :: LowHighWhere -> Bool
-isLow (Low _) = True
+isLow (LH Low _) = True
 isLow _ = False
 
 -- | Utility value for whether to keep or drop values.

--- a/src/Tablebot/Plugins/Roll/Dice/DiceEval.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceEval.hs
@@ -318,12 +318,12 @@ evalDieOp' (MkDieOpOption doo : doos) die is = do
   is' <- evalDieOp'' doo' die is
   evalDieOp' doos die is'
   where
-    processLHW (Low i) = do
+    processLHW (LH Low i) = do
       (i', _) <- evalShow i
-      return (Low (Value i'))
-    processLHW (High i) = do
+      return (LH Low (Value i'))
+    processLHW (LH High i) = do
       (i', _) <- evalShow i
-      return (High (Value i'))
+      return (LH High (Value i'))
     processLHW (Where o i) = do
       (i', _) <- evalShow i
       return (Where o (Value i'))

--- a/src/Tablebot/Plugins/Roll/Dice/DiceEval.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceEval.hs
@@ -234,31 +234,32 @@ instance IOEval Base where
       _ -> evaluationException ("could not find integer variable `" <> t <> "`") []
 
 instance IOEval Die where
-  evalShow' ld@(LazyDie d) = do
-    (i, _) <- evalShow d
-    ds <- dieShow Nothing ld [(i, Nothing)]
-    return (i, ds)
-  evalShow' d@(CustomDie (LVBList es)) = do
-    e <- liftIO $ chooseOne es
-    (i, _) <- evalShow e
-    ds <- dieShow Nothing d [(i, Nothing)]
-    incRNGCount
-    return (i, ds)
-  evalShow' d@(CustomDie is) = do
-    (is', _) <- evalShowL is
-    i <- liftIO $ chooseOne (fst <$> is')
-    ds <- dieShow Nothing d [(i, Nothing)]
-    incRNGCount
-    return (i, ds)
-  evalShow' d@(Die b) = do
-    (bound, _) <- evalShow b
-    if bound < 1
-      then evaluationException ("Cannot roll a < 1 sided die (" <> formatText Code (parseShow b) <> ")") []
-      else do
-        i <- randomRIO (1, bound)
-        ds <- dieShow Nothing d [(i, Nothing)]
-        incRNGCount
-        return (i, ds)
+  evalShow' theDie@(MkDie aDie) = case aDie of
+    LazyDie d -> do
+      (i, _) <- evalShow (MkDie d)
+      ds <- dieShow Nothing (MkDie d) [(i, Nothing)]
+      return (i, ds)
+    CustomDie (LVBList es) -> do
+      e <- liftIO $ chooseOne es
+      (i, _) <- evalShow e
+      ds <- dieShow Nothing theDie [(i, Nothing)]
+      incRNGCount
+      return (i, ds)
+    CustomDie is -> do
+      (is', _) <- evalShowL is
+      i <- liftIO $ chooseOne (fst <$> is')
+      ds <- dieShow Nothing theDie [(i, Nothing)]
+      incRNGCount
+      return (i, ds)
+    Die b -> do
+      (bound, _) <- evalShow b
+      if bound < 1
+        then evaluationException ("Cannot roll a < 1 sided die (" <> formatText Code (parseShow b) <> ")") []
+        else do
+          i <- randomRIO (1, bound)
+          ds <- dieShow Nothing theDie [(i, Nothing)]
+          incRNGCount
+          return (i, ds)
 
 instance IOEval Dice where
   evalShow' dop = do
@@ -296,25 +297,26 @@ evalDieOp (Dice b ds dopo) = do
           rs <- evalDieOp' dopo ds' vs
           return (sortBy sortByOption rs, crits)
   where
-    condenseDie (Die dBase) = do
-      (i, _) <- evalShow dBase
-      return (Die (Value i), Just (1, i))
-    condenseDie (CustomDie is) = do
-      (is', _) <- evalShowL is
-      return (CustomDie (LVBList (promote . fst <$> is')), Nothing)
-    condenseDie (LazyDie d) = return (d, Nothing)
+    condenseDie (MkDie d) = case d of
+      Die dBase -> do
+        (i, _) <- evalShow dBase
+        return (MkDie (Die (Value i)), Just (1, i))
+      CustomDie is -> do
+        (is', _) <- evalShowL is
+        return (MkDie (CustomDie (LVBList (promote . fst <$> is'))), Nothing)
+      LazyDie d' -> return (MkDie d', Nothing)
     sortByOption (e :| es, _) (f :| fs, _)
       | e == f = compare (length fs) (length es)
       | otherwise = compare e f
 
 -- | Utility function that processes a `Maybe DieOpRecur`, when given a die, and
 -- dice that have already been processed.
-evalDieOp' :: Maybe DieOpRecur -> Die -> [(NonEmpty Integer, Bool)] -> ProgramStateM [(NonEmpty Integer, Bool)]
-evalDieOp' Nothing _ is = return is
-evalDieOp' (Just (DieOpRecur doo mdor)) die is = do
-  doo' <- processDOO doo
+evalDieOp' :: [DieOpOption] -> Die -> [(NonEmpty Integer, Bool)] -> ProgramStateM [(NonEmpty Integer, Bool)]
+evalDieOp' [] _ is = return is
+evalDieOp' (MkDieOpOption doo : doos) die is = do
+  doo' <- processDOO
   is' <- evalDieOp'' doo' die is
-  evalDieOp' mdor die is'
+  evalDieOp' doos die is'
   where
     processLHW (Low i) = do
       (i', _) <- evalShow i
@@ -325,32 +327,34 @@ evalDieOp' (Just (DieOpRecur doo mdor)) die is = do
     processLHW (Where o i) = do
       (i', _) <- evalShow i
       return (Where o (Value i'))
-    processDOO (DieOpOptionKD kd lhw) = do
-      lhw' <- processLHW lhw
-      return (DieOpOptionKD kd lhw')
-    processDOO (Reroll once o i) = do
-      (i', _) <- evalShow i
-      return (Reroll once o (Value i'))
-    processDOO (DieOpOptionLazy doo') = return doo'
+    processDOO = case doo of
+      DieOpOptionKD kd lhw -> do
+        lhw' <- processLHW lhw
+        return $ MkDieOpOption (DieOpOptionKD kd lhw')
+      Reroll once o i -> do
+        (i', _) <- evalShow i
+        return $ MkDieOpOption (Reroll once o (Value i'))
+      DieOpOptionLazy doo' -> return $ MkDieOpOption doo'
 
 -- | Utility function that processes a `DieOpOption`, when given a die, and dice
 -- that have already been processed.
 evalDieOp'' :: DieOpOption -> Die -> [(NonEmpty Integer, Bool)] -> ProgramStateM [(NonEmpty Integer, Bool)]
-evalDieOp'' (DieOpOptionLazy doo) die is = evalDieOp'' doo die is
-evalDieOp'' (DieOpOptionKD kd lhw) _ is = evalDieOpHelpKD kd lhw is
-evalDieOp'' (Reroll once o i) die is = foldr rerollF (return []) is
-  where
-    rerollF g@(i', b) isRngCount' = do
-      is' <- isRngCount'
-      (iEval, _) <- evalShow i
-      if b && applyCompare o (NE.head i') iEval
-        then do
-          (v, _) <- evalShow die
-          let ret = (v <| i', b)
-          if once
-            then return (ret : is')
-            else rerollF ret (return is')
-        else return (g : is')
+evalDieOp'' (MkDieOpOption doo) die is = case doo of
+  DieOpOptionLazy doo' -> evalDieOp'' (MkDieOpOption doo') die is
+  DieOpOptionKD kd lhw -> evalDieOpHelpKD kd lhw is
+  Reroll once o i -> foldr rerollF (return []) is
+    where
+      rerollF g@(i', b) isRngCount' = do
+        is' <- isRngCount'
+        (iEval, _) <- evalShow i
+        if b && applyCompare o (NE.head i') iEval
+          then do
+            (v, _) <- evalShow die
+            let ret = (v <| i', b)
+            if once
+              then return (ret : is')
+              else rerollF ret (return is')
+          else return (g : is')
 
 -- | Given a list of dice values, separate them into kept values and dropped values
 -- respectively.

--- a/src/Tablebot/Plugins/Roll/Dice/DiceFunctions.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceFunctions.hs
@@ -128,10 +128,13 @@ funcInfoInsert = FuncInfo "insert" [ATInteger, ATInteger, ATIntegerList] ATInteg
 -- including types, the function name, and the function itself.
 data FuncInfoBase j = FuncInfo {funcInfoName :: Text, funcInfoParameters :: [ArgType], funcReturnType :: ArgType, funcInfoFunc :: forall m. (MonadException m) => [ListInteger] -> m j}
 
+instance Eq (FuncInfoBase j) where
+  (==) fib1 fib2 = funcInfoName fib1 == funcInfoName fib2
+
 type FuncInfo = FuncInfoBase Integer
 
 instance Show (FuncInfoBase j) where
-  show (FuncInfo fin ft frt _) = "FuncInfo " <> unpack fin <> " " <> show ft <> " " <> show frt
+  show (FuncInfo fin ft frt _) = "FuncInfo \"" <> unpack fin <> "\" " <> show ft <> " " <> show frt
 
 -- | A simple way to construct a function that returns a value j, and has no
 -- constraints on the given values.

--- a/src/Tablebot/Plugins/Roll/Dice/DiceParsing.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceParsing.hs
@@ -157,7 +157,12 @@ functionParser m mainCons =
   do
     fi <- try (choice (string <$> functionNames) >>= \t -> return (m M.! t)) <?> "could not find function"
     let ft = funcInfoParameters fi
-    es <- skipSpace *> string "(" *> skipSpace *> parseArgValues ft <* skipSpace <* (string ")" <??> "could not find closing bracket on function call")
+    es <- skipSpace *>
+      try (string "(" <??> ("could not find opening bracket for function call: \"" <> T.unpack (funcInfoName fi) <> "\"")) *>
+        skipSpace *>
+          parseArgValues ft
+            <* skipSpace
+              <* (string ")" <??> "could not find closing bracket on function call")
     return $ mainCons fi es
   where
     functionNames = sortBy (\a b -> compare (T.length b) (T.length a)) $ M.keys m

--- a/src/Tablebot/Plugins/Roll/Dice/DiceParsing.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceParsing.hs
@@ -113,7 +113,7 @@ binOpParseHelp c con = try (skipSpace *> char c) *> skipSpace *> (con <$> pars)
 
 instance (CanParse b) => CanParse (If b) where
   pars = do
-    a <- string "if" *> skipSpace1 *> pars <* skipSpace1
+    a <- try (string "if" *> skipSpace1) *> pars <* skipSpace1
     t <- string "then" *> skipSpace1 *> pars <* skipSpace1
     e <- string "else" *> skipSpace1 *> pars
     return $ If a t e

--- a/src/Tablebot/Plugins/Roll/Dice/DiceParsing.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceParsing.hs
@@ -241,8 +241,8 @@ parseAdvancedOrdering = (try (choice opts) <?> "could not parse an ordering") >>
 parseLowHigh :: Parser LowHighWhere
 parseLowHigh = ((choice @[] $ char <$> "lhw") <??> "could not parse high, low or where") >>= helper
   where
-    helper 'h' = High <$> pars
-    helper 'l' = Low <$> pars
+    helper 'h' = LH High <$> pars
+    helper 'l' = LH Low <$> pars
     helper 'w' = parseAdvancedOrdering >>= \o -> pars <&> Where o
     helper c = failure' (T.singleton c) (S.fromList ["h", "l", "w"])
 
@@ -350,8 +350,8 @@ instance ParseShow Dice where
     where
       fromOrdering ao = M.findWithDefault "??" ao $ snd advancedOrderingMapping
       fromLHW (Where o i) = "w" <> fromOrdering o <> parseShow i
-      fromLHW (Low i) = "l" <> parseShow i
-      fromLHW (High i) = "h" <> parseShow i
+      fromLHW (LH Low i) = "l" <> parseShow i
+      fromLHW (LH High i) = "h" <> parseShow i
       helper' [] = ""
       helper' (dopo' : dor') = helper dopo' <> helper' dor'
       helper (MkDieOpOption doo) = case doo of

--- a/src/Tablebot/Plugins/Roll/Dice/DiceParsing.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceParsing.hs
@@ -191,9 +191,8 @@ instance CanParse Base where
         (DiceBase <$> parseDice nb)
           <|> return (NBase nb)
     )
-      <|> DiceBase
-      <$> parseDice (Value 1)
-        <|> (NumVar <$> try variableName)
+      <|> (DiceBase <$> try (parseDice (Value 1)))
+      <|> (NumVar <$> try variableName)
 
 instance CanParse Die where
   pars = do

--- a/src/Tablebot/Plugins/Roll/Dice/DiceStats.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceStats.hs
@@ -186,7 +186,7 @@ getDiceDistrbutionFrom dieNumber die =
 -- based on those operations.
 rangeDiceExperiment :: (MonadException m) => Distribution -> [DieOpOption] -> m (DistributionSortedList -> DistributionSortedList)
 rangeDiceExperiment die =
-  fmap (appEndo . fold) . traverse (rangeDieOpExperiment die)
+  fmap (appEndo . fold . reverse) . traverse (rangeDieOpExperiment die)
 
 -- | Perform one dice operation on a set of values, returning
 -- a modified distribution of dice rolls.

--- a/src/Tablebot/Plugins/Roll/Dice/DiceStats.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceStats.hs
@@ -56,16 +56,16 @@ rangeListValues lv = do
     getTails xs = first (drop 1) <$> xs
     zip' xs = getHeads xs : zip' (getTails xs)
 
+-- | Try and get the `Distribution` of the given value, throwing a
+-- `MonadException` on failure.
+range :: (MonadException m, Range a, ParseShow a) => a -> m Distribution
+range a = propagateException (parseShow a) (range' a)
+
 -- | Type class to get the overall range of a value.
 --
 -- A `Data.Distribution.Distribution` is a map of values to probabilities, and
 -- has a variety of  functions that operate on them.
 class (ParseShow a) => Range a where
-  -- | Try and get the `Distribution` of the given value, throwing a
-  -- `MonadException` on failure.
-  range :: (MonadException m, ParseShow a) => a -> m Distribution
-  range a = propagateException (parseShow a) (range' a)
-
   range' :: (MonadException m, ParseShow a) => a -> m Distribution
 
 instance (Range a) => Range (MiscData a) where
@@ -242,16 +242,16 @@ rangeDieOpExperimentKD kd (LH lw nb) is = do
       Low -> splitL
       High -> splitR
 
+-- | Try and get the `DistributionList` of the given value, throwing a
+-- `MonadException` on failure.
+rangeList :: (MonadException m, RangeList a, ParseShow a) => a -> m DistributionList
+rangeList a = propagateException (parseShow a) (rangeList' a)
+
 -- | Type class to get the overall range of a list of values.
 --
 -- Only used within `DiceStats` as I have no interest in producing statistics on
 -- lists
 class (ParseShow a) => RangeList a where
-  -- | Try and get the `DistributionList` of the given value, throwing a
-  -- `MonadException` on failure.
-  rangeList :: (MonadException m, ParseShow a) => a -> m DistributionList
-  rangeList a = propagateException (parseShow a) (rangeList' a)
-
   rangeList' :: (MonadException m, ParseShow a) => a -> m DistributionList
 
 instance RangeList ListValuesBase where

--- a/src/Tablebot/Plugins/Roll/Dice/DiceStats.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceStats.hs
@@ -99,7 +99,7 @@ instance (RangeList a) => RangeList (Var a) where
   rangeList' (Var _ a) = rangeList a
   rangeList' (VarLazy _ a) = rangeList a
 
-instance (ParseShow typ, Range sub) => Range (BinOp sub typ) where
+instance (ParseShow typ, Operation typ, Range sub) => Range (BinOp sub typ) where
   range' (BinOp a tas) = foldl' foldel (range a) tas
     where
       foldel at (typ, b) = do

--- a/src/Tablebot/Plugins/Roll/Dice/DiceStats.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceStats.hs
@@ -279,4 +279,4 @@ rangeFunction fi exprs = do
   let params = first (funcInfoFunc fi) <$> D.toList (D.run $ sequence exprs')
   D.from . D.fromList <$> foldAndIgnoreErrors params
   where
-    foldAndIgnoreErrors = foldr (\(mv, p) mb -> mb >>= \b -> catchBot ((: []) . (,p) <$> mv) (const (return [])) >>= \v -> return (v ++ b)) (return [])
+    foldAndIgnoreErrors = foldr (\(mv, p) mb -> catchBot ((: []) . (,p) <$> mv) (const (return [])) >>= \v -> mb >>= \b -> return (v ++ b)) (return [])

--- a/src/Tablebot/Plugins/Roll/Dice/DiceStats.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceStats.hs
@@ -229,21 +229,16 @@ rangeDieOpExperimentKD kd (Where cond nb) is = do
     keepDrop
       | kd == Keep = id
       | otherwise = not
-rangeDieOpExperimentKD kd lhw is = do
-  let nb = getValueLowHigh lhw
-  case nb of
-    Nothing -> whereException
-    Just nb' -> do
-      nbd <- range nb'
-      return $ DM.do
-        kdlh <- nbd
-        (getKeep kdlh . sortBy') DM.<$> is
+rangeDieOpExperimentKD kd (LH lw nb) is = do
+  nbd <- range nb
+  return $ DM.do
+    kdlh <- nbd
+    (getKeep kdlh . sortBy') DM.<$> is
   where
-    -- the below exception should never trigger - it is a hold over. it is
-    -- present so that this thing type checks nicely.
-    whereException = evaluationException "keep/drop where is unsupported" []
-    order l l' = if isLow lhw then compare l l' else compare l' l
-    sortBy' = sortBy order
+    order = case lw of
+      Low -> id
+      High -> flip
+    sortBy' = sortBy (order compare)
     getKeep = if kd == Keep then genericTake else genericDrop
 
 -- | Type class to get the overall range of a list of values.

--- a/src/Tablebot/Plugins/Roll/Dice/DiceStats.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceStats.hs
@@ -21,10 +21,9 @@ import Tablebot.Plugins.Roll.Dice.DiceData
 import Tablebot.Plugins.Roll.Dice.DiceEval
 import Tablebot.Plugins.Roll.Dice.DiceFunctions
 import Tablebot.Plugins.Roll.Dice.DiceStatsBase (Distribution)
-import Tablebot.Utility.Exception (catchBot)
-
 import qualified Tablebot.Plugins.Roll.Dice.DistributionMonad as DM
 import Tablebot.Plugins.Roll.Dice.SortedList as SL
+import Tablebot.Utility.Exception (catchBot)
 
 type DistributionSortedList = D.Distribution (SortedList Integer)
 

--- a/src/Tablebot/Plugins/Roll/Dice/DiceStatsBase.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DiceStatsBase.hs
@@ -67,7 +67,13 @@ distributionRenderable d = toRenderable $ do
   layout_x_axis . laxis_title .= "value"
   layout_y_axis . laxis_title .= "probability (%)"
   layout_x_axis . laxis_generate .= scaledIntAxis' r
-  layout_y_axis . laxis_override .= \ad@AxisData {_axis_labels = axisLabels} -> ad {_axis_labels = (second (\s -> if '.' `elem` s then s else s ++ ".0") <$>) <$> axisLabels}
+  layout_y_axis
+    . laxis_override
+    .= \ad@AxisData {_axis_labels = axisLabels} ->
+      ad
+        { _axis_labels =
+            (second (\s -> if '.' `elem` s then s else s ++ ".0") <$>) <$> axisLabels
+        }
   layout_all_font_styles .= defFontStyle
   pb <- (bars @Integer @Double) (barNames d) pts
   let pb' = set plot_bars_spacing (BarsFixGap 10 5) pb
@@ -79,7 +85,7 @@ distributionRenderable d = toRenderable $ do
     ds = removeNullMap . D.toMap . fst <$> d
     allIntegers = let s = S.unions $ M.keysSet <$> ds in [S.findMin s .. S.findMax s]
     insertEmpty k = M.insertWith (\_ a -> a) k 0
-    ds' = M.unionsWith (++) $ M.map (: []) <$> (applyAll (insertEmpty <$> allIntegers) <$> ds)
+    ds' = M.unionsWith (++) $ M.map (: []) . applyAll (insertEmpty <$> allIntegers) <$> ds
     pts = second (fromRational . (* 100) <$>) <$> M.toList ds'
     r = (fst $ M.findMin ds', fst $ M.findMax ds')
     applyAll [] = id

--- a/src/Tablebot/Plugins/Roll/Dice/DistributionMonad.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DistributionMonad.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
 module Tablebot.Plugins.Roll.Dice.DistributionMonad where
 
 import Data.Distribution.Core
-import Data.Ord (Ord)
 import Data.Function (id)
 import Data.Monoid
+import Data.Ord (Ord)
 import Tablebot.Plugins.Roll.Dice.SortedList as SL
 
 (>>=) :: (Ord b) => Distribution a -> (a -> Distribution b) -> Distribution b
@@ -15,10 +15,10 @@ import Tablebot.Plugins.Roll.Dice.SortedList as SL
 return :: a -> Distribution a
 return = always
 
-(<$>) :: Ord b => (a -> b) -> Distribution a -> Distribution b
+(<$>) :: (Ord b) => (a -> b) -> Distribution a -> Distribution b
 (<$>) = select
 
-traverse :: Ord b => (a -> Distribution b) -> [a] -> Distribution [b]
+traverse :: (Ord b) => (a -> Distribution b) -> [a] -> Distribution [b]
 traverse _ [] = return []
 traverse f (a : as) =
   f a >>= \b -> (b :) <$> traverse f as

--- a/src/Tablebot/Plugins/Roll/Dice/DistributionMonad.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DistributionMonad.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE QualifiedDo #-}
+
+module Tablebot.Plugins.Roll.Dice.DistributionMonad where
+
+import Data.Distribution.Core
+import Data.Ord (Ord)
+import Data.Function (id)
+
+(>>=) :: (Ord b) => Distribution a -> (a -> Distribution b) -> Distribution b
+(>>=) = andThen
+
+return :: a -> Distribution a
+return = always
+
+(<$>) :: Ord b => (a -> b) -> Distribution a -> Distribution b
+(<$>) = select
+
+traverse :: Ord b => (a -> Distribution b) -> [a] -> Distribution [b]
+traverse _ [] = return []
+traverse f (a : as) = f a >>= \b -> (b :) <$> traverse f as
+
+sequence :: Ord a => [Distribution a] -> Distribution [a]
+sequence = traverse id

--- a/src/Tablebot/Plugins/Roll/Dice/DistributionMonad.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DistributionMonad.hs
@@ -6,6 +6,7 @@ module Tablebot.Plugins.Roll.Dice.DistributionMonad where
 import Data.Distribution.Core
 import Data.Ord (Ord)
 import Data.Function (id)
+import Tablebot.Plugins.Roll.Dice.SortedList as SL
 
 (>>=) :: (Ord b) => Distribution a -> (a -> Distribution b) -> Distribution b
 (>>=) = andThen
@@ -22,3 +23,7 @@ traverse f (a : as) = f a >>= \b -> (b :) <$> traverse f as
 
 sequence :: Ord a => [Distribution a] -> Distribution [a]
 sequence = traverse id
+
+sequenceSL :: (Ord a) => [Distribution a] -> Distribution (SortedList a)
+sequenceSL [] = return mempty
+sequenceSL (da : das) = da >>= \a -> SL.insert a <$> sequenceSL das

--- a/src/Tablebot/Plugins/Roll/Dice/DistributionMonad.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/DistributionMonad.hs
@@ -6,6 +6,7 @@ module Tablebot.Plugins.Roll.Dice.DistributionMonad where
 import Data.Distribution.Core
 import Data.Ord (Ord)
 import Data.Function (id)
+import Data.Monoid
 import Tablebot.Plugins.Roll.Dice.SortedList as SL
 
 (>>=) :: (Ord b) => Distribution a -> (a -> Distribution b) -> Distribution b
@@ -19,9 +20,10 @@ return = always
 
 traverse :: Ord b => (a -> Distribution b) -> [a] -> Distribution [b]
 traverse _ [] = return []
-traverse f (a : as) = f a >>= \b -> (b :) <$> traverse f as
+traverse f (a : as) =
+  f a >>= \b -> (b :) <$> traverse f as
 
-sequence :: Ord a => [Distribution a] -> Distribution [a]
+sequence :: (Ord a) => [Distribution a] -> Distribution [a]
 sequence = traverse id
 
 sequenceSL :: (Ord a) => [Distribution a] -> Distribution (SortedList a)

--- a/src/Tablebot/Plugins/Roll/Dice/SortedList.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/SortedList.hs
@@ -1,66 +1,69 @@
+module Tablebot.Plugins.Roll.Dice.SortedList
+  ( SortedList,
+    toList,
+    fromList,
+    insert,
+    Tablebot.Plugins.Roll.Dice.SortedList.filter,
+    splitL,
+    splitR,
+  )
+where
 
-module Tablebot.Plugins.Roll.Dice.SortedList 
-  ( SortedList
-  , toList
-  , fromList
-  , insert
-  , Tablebot.Plugins.Roll.Dice.SortedList.filter
-  , splitL
-  , splitR
-  ) where
-
-import qualified Data.Map.Strict as M
-import qualified Data.Foldable
 import Data.Bifunctor
+import qualified Data.Foldable
+import qualified Data.Map.Strict as M
 
 newtype SortedList a = MkSortedList (M.Map a Int)
   deriving (Eq, Ord, Show)
 
-fromList :: Ord a => [a] -> SortedList a
-fromList = MkSortedList . M.fromListWith (+) . fmap (, 1)
+fromList :: (Ord a) => [a] -> SortedList a
+fromList = MkSortedList . M.fromListWith (+) . fmap (,1)
 
 toList :: SortedList a -> [a]
 toList (MkSortedList m) = do
   (a, incidence) <- M.toAscList m
   replicate incidence a
 
-insert :: Ord a => a -> SortedList a -> SortedList a
+insert :: (Ord a) => a -> SortedList a -> SortedList a
 insert a (MkSortedList m) = MkSortedList $ M.insertWith (+) a 1 m
 
-filter ::  (a -> Bool) -> SortedList a -> SortedList a
+filter :: (a -> Bool) -> SortedList a -> SortedList a
 filter p (MkSortedList m) = MkSortedList $ M.filterWithKey (\k _ -> p k) m
 
-splitR :: Ord a => Int -> SortedList a -> (SortedList a, SortedList a)
+splitR :: (Ord a) => Int -> SortedList a -> (SortedList a, SortedList a)
 splitR i sl@(MkSortedList m)
   | i <= 0 = (mempty, sl)
   | otherwise =
-    bimap (MkSortedList . M.fromDescList) (MkSortedList . M.fromDescList) $
-      splitCount i (M.toDescList m)
+      bimap (MkSortedList . M.fromDescList) (MkSortedList . M.fromDescList) $
+        splitCount i (M.toDescList m)
 
-splitL :: Ord a => Int -> SortedList a -> (SortedList a, SortedList a)
+splitL :: (Ord a) => Int -> SortedList a -> (SortedList a, SortedList a)
 splitL i sl@(MkSortedList m)
   | i <= 0 = (mempty, sl)
   | otherwise =
-    bimap (MkSortedList . M.fromAscList) (MkSortedList . M.fromAscList) $
-      splitCount i (M.toAscList m)
+      bimap (MkSortedList . M.fromAscList) (MkSortedList . M.fromAscList) $
+        splitCount i (M.toAscList m)
 
 -- | Split the list by using the int values associated with each value as a count.
 splitCount :: Int -> [(a, Int)] -> ([(a, Int)], [(a, Int)])
 splitCount 0 as = ([], as)
 splitCount _ [] = ([], [])
-splitCount i (aTup@(a, i'):as)
+splitCount i (aTup@(a, i') : as)
   | i >= i' = first (aTup :) $ splitCount (i - i') as
-  | otherwise = ([(a, i)],(a,i' - i):as)
+  | otherwise = ([(a, i)], (a, i' - i) : as)
 
 instance Foldable SortedList where
   foldMap f = foldMap f . toList
-  sum (MkSortedList m) = M.foldlWithKey' 
-    (\acc k incidence -> acc + k * (fromIntegral incidence)) 0 m
+  sum (MkSortedList m) =
+    M.foldlWithKey'
+      (\acc k incidence -> acc + k * (fromIntegral incidence))
+      0
+      m
   toList = Tablebot.Plugins.Roll.Dice.SortedList.toList
   length (MkSortedList m) = sum m
 
-instance Ord a => Semigroup (SortedList a) where
+instance (Ord a) => Semigroup (SortedList a) where
   (MkSortedList m1) <> (MkSortedList m2) = MkSortedList (M.unionWith (+) m1 m2)
 
-instance Ord a => Monoid (SortedList a) where
+instance (Ord a) => Monoid (SortedList a) where
   mempty = MkSortedList M.empty

--- a/src/Tablebot/Plugins/Roll/Dice/SortedList.hs
+++ b/src/Tablebot/Plugins/Roll/Dice/SortedList.hs
@@ -1,0 +1,66 @@
+
+module Tablebot.Plugins.Roll.Dice.SortedList 
+  ( SortedList
+  , toList
+  , fromList
+  , insert
+  , Tablebot.Plugins.Roll.Dice.SortedList.filter
+  , splitL
+  , splitR
+  ) where
+
+import qualified Data.Map.Strict as M
+import qualified Data.Foldable
+import Data.Bifunctor
+
+newtype SortedList a = MkSortedList (M.Map a Int)
+  deriving (Eq, Ord, Show)
+
+fromList :: Ord a => [a] -> SortedList a
+fromList = MkSortedList . M.fromListWith (+) . fmap (, 1)
+
+toList :: SortedList a -> [a]
+toList (MkSortedList m) = do
+  (a, incidence) <- M.toAscList m
+  replicate incidence a
+
+insert :: Ord a => a -> SortedList a -> SortedList a
+insert a (MkSortedList m) = MkSortedList $ M.insertWith (+) a 1 m
+
+filter ::  (a -> Bool) -> SortedList a -> SortedList a
+filter p (MkSortedList m) = MkSortedList $ M.filterWithKey (\k _ -> p k) m
+
+splitR :: Ord a => Int -> SortedList a -> (SortedList a, SortedList a)
+splitR i sl@(MkSortedList m)
+  | i <= 0 = (mempty, sl)
+  | otherwise =
+    bimap (MkSortedList . M.fromDescList) (MkSortedList . M.fromDescList) $
+      splitCount i (M.toDescList m)
+
+splitL :: Ord a => Int -> SortedList a -> (SortedList a, SortedList a)
+splitL i sl@(MkSortedList m)
+  | i <= 0 = (mempty, sl)
+  | otherwise =
+    bimap (MkSortedList . M.fromAscList) (MkSortedList . M.fromAscList) $
+      splitCount i (M.toAscList m)
+
+-- | Split the list by using the int values associated with each value as a count.
+splitCount :: Int -> [(a, Int)] -> ([(a, Int)], [(a, Int)])
+splitCount 0 as = ([], as)
+splitCount _ [] = ([], [])
+splitCount i (aTup@(a, i'):as)
+  | i >= i' = first (aTup :) $ splitCount (i - i') as
+  | otherwise = ([(a, i)],(a,i' - i):as)
+
+instance Foldable SortedList where
+  foldMap f = foldMap f . toList
+  sum (MkSortedList m) = M.foldlWithKey' 
+    (\acc k incidence -> acc + k * (fromIntegral incidence)) 0 m
+  toList = Tablebot.Plugins.Roll.Dice.SortedList.toList
+  length (MkSortedList m) = sum m
+
+instance Ord a => Semigroup (SortedList a) where
+  (MkSortedList m1) <> (MkSortedList m2) = MkSortedList (M.unionWith (+) m1 m2)
+
+instance Ord a => Monoid (SortedList a) where
+  mempty = MkSortedList M.empty

--- a/src/Tablebot/Plugins/Roll/Plugin.hs
+++ b/src/Tablebot/Plugins/Roll/Plugin.hs
@@ -207,8 +207,8 @@ genchar = Command "genchar" (snd $ NE.head rpgSystems') (toCommand <$> NE.toList
 -- | List of supported genchar systems and the dice used to roll for them
 rpgSystems :: NE.NonEmpty (Text, ListValues)
 rpgSystems =
-  ("dnd", MultipleValues (Value 6) (DiceBase (Dice (NBase (Value 4)) (Die (Value 6)) (Just (DieOpRecur (DieOpOptionKD Drop (Low (Value 1))) Nothing)))))
-    NE.:| [("wfrp", MultipleValues (Value 8) (NBase (NBParen (Paren (Expr (BinOp (promote (Value 20)) [(Add, promote (Die (Value 10)))]))))))]
+  ("dnd", MultipleValues (Value 6) (DiceBase (Dice (Value 4) (MkDie (Die (Value 6))) [MkDieOpOption (DieOpOptionKD Drop (Low (Value 1)))])))
+    NE.:| [("wfrp", MultipleValues (Value 8) (NBase (NBParen (Paren (Expr (BinOp (promote (Value 20)) [(Add, promote (MkDie (Die (Value 10))))]))))))]
 
 -- | Small help page for gen char.
 gencharHelp :: HelpPage

--- a/src/Tablebot/Plugins/Roll/Plugin.hs
+++ b/src/Tablebot/Plugins/Roll/Plugin.hs
@@ -207,7 +207,7 @@ genchar = Command "genchar" (snd $ NE.head rpgSystems') (toCommand <$> NE.toList
 -- | List of supported genchar systems and the dice used to roll for them
 rpgSystems :: NE.NonEmpty (Text, ListValues)
 rpgSystems =
-  ("dnd", MultipleValues (Value 6) (DiceBase (Dice (Value 4) (MkDie (Die (Value 6))) [MkDieOpOption (DieOpOptionKD Drop (Low (Value 1)))])))
+  ("dnd", MultipleValues (Value 6) (DiceBase (Dice (Value 4) (MkDie (Die (Value 6))) [MkDieOpOption (DieOpOptionKD Drop (LH Low (Value 1)))])))
     NE.:| [("wfrp", MultipleValues (Value 8) (NBase (NBParen (Paren (Expr (BinOp (promote (Value 20)) [(Add, promote (MkDie (Die (Value 10))))]))))))]
 
 -- | Small help page for gen char.

--- a/stack.yaml
+++ b/stack.yaml
@@ -47,7 +47,7 @@ extra-deps:
 - persistent-2.17.1.0
 - svg-builder-0.1.1
 - git: https://github.com/L0neGamer/haskell-distribution.git
-  commit: 569d6452e4bffedb2c0d3795885fccdb22a4d29d
+  commit: 313eb7a280b010fda1e21876da4171503c76516f
 - git: https://github.com/L0neGamer/duckling.git
   commit: f22e3cdd7b77977fe3e9ec75fccd9a0f79c47f97
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -40,15 +40,15 @@ packages:
   original:
     hackage: svg-builder-0.1.1
 - completed:
-    commit: 569d6452e4bffedb2c0d3795885fccdb22a4d29d
+    commit: 313eb7a280b010fda1e21876da4171503c76516f
     git: https://github.com/L0neGamer/haskell-distribution.git
     name: distribution
     pantry-tree:
-      sha256: df46a8ef68d35f55bdcf3d6c6e5578cad5680306a7bef4e52da8631cc171c1fc
+      sha256: b1d8fce7d72787aa7de1c14b65c6a5c633e079da2a1e77b129e0270574231301
       size: 808
     version: 1.1.1.1
   original:
-    commit: 569d6452e4bffedb2c0d3795885fccdb22a4d29d
+    commit: 313eb7a280b010fda1e21876da4171503c76516f
     git: https://github.com/L0neGamer/haskell-distribution.git
 - completed:
     commit: f22e3cdd7b77977fe3e9ec75fccd9a0f79c47f97

--- a/tablebot.cabal
+++ b/tablebot.cabal
@@ -78,6 +78,7 @@ library
       Tablebot.Plugins.Roll.Dice.DiceParsing
       Tablebot.Plugins.Roll.Dice.DiceStats
       Tablebot.Plugins.Roll.Dice.DiceStatsBase
+      Tablebot.Plugins.Roll.Dice.DistributionMonad
       Tablebot.Plugins.Roll.Plugin
       Tablebot.Plugins.Say
       Tablebot.Plugins.Shibe

--- a/tablebot.cabal
+++ b/tablebot.cabal
@@ -252,10 +252,13 @@ test-suite tablebot-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Dice.RoundtripSpec
       Paths_tablebot
   hs-source-dirs:
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-tool-depends:
+      tasty-discover:tasty-discover
   build-depends:
       Chart
     , Chart-diagrams
@@ -279,6 +282,9 @@ test-suite tablebot-test
     , extra
     , filepath
     , hashable
+    , hedgehog
+    , hspec
+    , hspec-hedgehog
     , http-client
     , http-conduit
     , load-env
@@ -299,6 +305,10 @@ test-suite tablebot-test
     , scientific
     , split
     , tablebot
+    , tasty
+    , tasty-discover
+    , tasty-hedgehog
+    , tasty-hspec
     , template-haskell
     , text
     , text-icu

--- a/tablebot.cabal
+++ b/tablebot.cabal
@@ -154,6 +154,7 @@ library
     , exception-transformers
     , extra
     , filepath
+    , hashable
     , http-client
     , http-conduit
     , load-env
@@ -214,6 +215,7 @@ executable tablebot-exe
     , exception-transformers
     , extra
     , filepath
+    , hashable
     , http-client
     , http-conduit
     , load-env
@@ -276,6 +278,7 @@ test-suite tablebot-test
     , exception-transformers
     , extra
     , filepath
+    , hashable
     , http-client
     , http-conduit
     , load-env

--- a/tablebot.cabal
+++ b/tablebot.cabal
@@ -155,7 +155,6 @@ library
     , exception-transformers
     , extra
     , filepath
-    , hashable
     , http-client
     , http-conduit
     , load-env
@@ -216,7 +215,6 @@ executable tablebot-exe
     , exception-transformers
     , extra
     , filepath
-    , hashable
     , http-client
     , http-conduit
     , load-env
@@ -282,7 +280,6 @@ test-suite tablebot-test
     , exception-transformers
     , extra
     , filepath
-    , hashable
     , hedgehog
     , hspec
     , hspec-hedgehog

--- a/tablebot.cabal
+++ b/tablebot.cabal
@@ -79,6 +79,7 @@ library
       Tablebot.Plugins.Roll.Dice.DiceStats
       Tablebot.Plugins.Roll.Dice.DiceStatsBase
       Tablebot.Plugins.Roll.Dice.DistributionMonad
+      Tablebot.Plugins.Roll.Dice.SortedList
       Tablebot.Plugins.Roll.Plugin
       Tablebot.Plugins.Say
       Tablebot.Plugins.Shibe

--- a/tablebot.cabal
+++ b/tablebot.cabal
@@ -192,7 +192,7 @@ executable tablebot-exe
       Paths_tablebot
   hs-source-dirs:
       app
-  ghc-options: -threaded -rtsopts "-with-rtsopts=-Iw10 -N"
+  ghc-options: -threaded -rtsopts -Wall "-with-rtsopts=-Iw10 -N"
   build-depends:
       Chart
     , Chart-diagrams
@@ -251,11 +251,12 @@ test-suite tablebot-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Dice.Gen
       Dice.RoundtripSpec
       Paths_tablebot
   hs-source-dirs:
       test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall
   build-tool-depends:
       tasty-discover:tasty-discover
   build-depends:

--- a/test/Dice/Gen.hs
+++ b/test/Dice/Gen.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Dice.Gen where
+
+import qualified Data.Text as T
+import Data.Traversable (for)
+import Hedgehog (MonadGen)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import Tablebot.Plugins.Roll.Dice.DiceData as Dice
+import Tablebot.Plugins.Roll.Dice.DiceFunctions
+  ( ArgType (ATInteger, ATIntegerList),
+    FuncInfoBase (..),
+    integerFunctions,
+    integerFunctionsList,
+    listFunctions,
+    listFunctionsList,
+  )
+
+genExpr :: (MonadGen m) => m Expr
+genExpr =
+  Gen.recursive Gen.choice [Expr <$> genBin genTerm] [Gen.subtermM genExpr $ \expr -> ExprMisc <$> genMisc False (pure expr)]
+
+genMisc :: (MonadGen m) => Bool -> m a -> m (MiscData a)
+genMisc isList genA = Gen.choice [MiscIf <$> genIf genA, MiscVar <$> genVar isList genA]
+
+genIf :: (MonadGen m) => m a -> m (If a)
+genIf genA = If <$> genExpr <*> genA <*> genA
+
+genVarName :: (MonadGen m) => m T.Text
+genVarName =
+  Gen.filterT (\var -> not $ any (`T.isPrefixOf` var) (integerFunctionsList <> listFunctionsList)) $
+    Gen.text (Range.linear 3 10) (Gen.element ['a' .. 'z'])
+
+genVar :: (MonadGen m) => Bool -> m a -> m (Dice.Var a)
+genVar isList genA =
+  Dice.Var
+    <$> ((if isList then ("l_" <>) else id) <$> genVarName)
+    <*> genA
+
+genBin :: (MonadGen m, Enum typ, Bounded typ) => m a -> m (BinOp a typ)
+genBin genA =
+  let opCount = Range.exponential 0 4
+   in BinOp
+        <$> genA
+        <*> Gen.list opCount ((,) <$> Gen.element [minBound .. maxBound] <*> genA)
+
+genTerm :: (MonadGen m) => m Term
+genTerm = Term <$> genBin genNeg
+
+genNeg :: (MonadGen m) => m Negation
+genNeg = Gen.frequency [(2, NoNeg <$> genExpo), (1, Neg <$> genExpo)]
+
+genExpo :: (MonadGen m) => m Expo
+genExpo =
+  Gen.recursive Gen.choice [NoExpo <$> genFunc] [Gen.subtermM genExpo (\expo -> (`Expo` expo) <$> genFunc)]
+
+genFunc :: (MonadGen m) => m Func
+genFunc =
+  Gen.frequency
+    [ (5, NoFunc <$> genBase),
+      (1, functionGen Func integerFunctions)
+    ]
+
+functionGen :: (Foldable f, MonadGen m) => (FuncInfoBase j -> [ArgValue] -> r) -> f (FuncInfoBase j) -> m r
+functionGen cons functions =
+  Gen.element functions >>= \func@(FuncInfo {..}) ->
+    cons func
+      <$> for
+        funcInfoParameters
+        ( \case
+            ATInteger -> AVExpr <$> genExpr
+            ATIntegerList -> AVListValues <$> genListValues
+        )
+
+genArg :: (MonadGen m) => m ArgValue
+genArg = Gen.choice [AVExpr <$> genExpr, AVListValues <$> genListValues]
+
+genBase :: (MonadGen m) => m Base
+genBase = Gen.frequency [(2, NBase <$> genNumBase), (2, DiceBase <$> genDice), (1, NumVar <$> genVarName)]
+
+genNumBase :: (MonadGen m) => m NumBase
+genNumBase =
+  Gen.recursive Gen.choice [Value <$> Gen.integral (Range.linear 0 100)] [NBParen . Paren <$> genExpr]
+
+genDice :: (MonadGen m) => m Dice
+genDice = Dice <$> genNumBase <*> genDie <*> Gen.list (Range.exponential 0 3) genDieOpOption
+
+genDie :: (MonadGen m) => m Die
+genDie = Gen.frequency (fmap (fmap (fmap MkDie)) strictDie <> [(1, MkDie . LazyDie <$> Gen.frequency strictDie)])
+  where
+    strictDie :: (MonadGen m) => [(Int, m (DieOf 'Strict))]
+    strictDie = [(3, Die <$> genNumBase), (1, CustomDie <$> genListValuesBase)]
+
+genDieOpOption :: (MonadGen m) => m DieOpOption
+genDieOpOption = Gen.choice (fmap (fmap MkDieOpOption) strictDieOp <> [MkDieOpOption . DieOpOptionLazy <$> Gen.choice strictDieOp])
+  where
+    strictDieOp :: (MonadGen m) => [m (DieOpOptionOf 'Strict)]
+    strictDieOp =
+      [ DieOpOptionKD
+          <$> Gen.element [Keep, Drop]
+          <*> Gen.frequency
+            [ (2, LH <$> Gen.element [Low, High] <*> genNumBase),
+              (1, Where <$> genAdvancedOrdering <*> genNumBase)
+            ],
+        Reroll <$> Gen.element [True, False] <*> genAdvancedOrdering <*> genNumBase
+      ]
+
+genAdvancedOrdering :: (MonadGen m) => m AdvancedOrdering
+genAdvancedOrdering = Gen.element $ fst advancedOrderingMapping
+
+genListValuesBase :: (MonadGen m) => m ListValuesBase
+genListValuesBase =
+  Gen.choice
+    [ LVBList <$> Gen.list (Range.exponential 1 10) genExpr,
+      LVBParen . Paren <$> genListValues
+    ]
+
+genListValues :: (MonadGen m) => m ListValues
+genListValues =
+  Gen.recursive
+    Gen.choice
+    [ LVVar . ("l_" <>) <$> genVarName
+    ]
+    [ MultipleValues <$> genNumBase <*> genBase,
+      LVBase <$> genListValuesBase,
+      ListValuesMisc <$> genMisc True genListValues,
+      functionGen LVFunc listFunctions
+    ]

--- a/test/Dice/RoundtripSpec.hs
+++ b/test/Dice/RoundtripSpec.hs
@@ -1,134 +1,14 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-
 module Dice.RoundtripSpec where
 
-import qualified Data.Text as T
-import Data.Traversable
+import Dice.Gen
 import Hedgehog
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
 import Tablebot.Plugins.Roll.Dice.DiceData as Dice
-import Tablebot.Plugins.Roll.Dice.DiceFunctions
 import Tablebot.Plugins.Roll.Dice.DiceParsing ()
 import Tablebot.Utility.Parser
 import Tablebot.Utility.SmartParser.SmartParser
 import Test.Hspec
 import Test.Hspec.Hedgehog ()
 import Text.Megaparsec (eof, runParser)
-
-genExpr :: (MonadGen m) => m Expr
-genExpr =
-  Gen.recursive Gen.choice [Expr <$> genBin genTerm] [Gen.subtermM genExpr $ \expr -> ExprMisc <$> genMisc False (pure expr)]
-
-genMisc :: (MonadGen m) => Bool -> m a -> m (MiscData a)
-genMisc isList genA = Gen.choice [MiscIf <$> genIf genA, MiscVar <$> genVar isList genA]
-
-genIf :: (MonadGen m) => m a -> m (If a)
-genIf genA = If <$> genExpr <*> genA <*> genA
-
-genVarName :: (MonadGen m) => m T.Text
-genVarName =
-  Gen.filterT (\var -> not $ any (`T.isPrefixOf` var) (integerFunctionsList <> listFunctionsList)) $
-    Gen.text (Range.linear 3 10) (Gen.element ['a' .. 'z'])
-
-genVar :: (MonadGen m) => Bool -> m a -> m (Dice.Var a)
-genVar isList genA =
-  Dice.Var
-    <$> ((if isList then ("l_" <>) else id) <$> genVarName)
-    <*> genA
-
-genBin :: (MonadGen m, Enum typ, Bounded typ) => m a -> m (BinOp a typ)
-genBin genA =
-  let opCount = Range.exponential 0 4
-   in BinOp
-        <$> genA
-        <*> Gen.list opCount ((,) <$> Gen.element [minBound .. maxBound] <*> genA)
-
-genTerm :: (MonadGen m) => m Term
-genTerm = Term <$> genBin genNeg
-
-genNeg :: (MonadGen m) => m Negation
-genNeg = Gen.frequency [(2, NoNeg <$> genExpo), (1, Neg <$> genExpo)]
-
-genExpo :: (MonadGen m) => m Expo
-genExpo =
-  Gen.recursive Gen.choice [NoExpo <$> genFunc] [Gen.subtermM genExpo (\expo -> (`Expo` expo) <$> genFunc)]
-
-genFunc :: (MonadGen m) => m Func
-genFunc =
-  Gen.frequency
-    [ (5, NoFunc <$> genBase),
-      (1, functionGen Func integerFunctions)
-    ]
-
-functionGen :: (Foldable f, MonadGen m) => (FuncInfoBase j -> [ArgValue] -> r) -> f (FuncInfoBase j) -> m r
-functionGen cons functions =
-  Gen.element functions >>= \func@(FuncInfo {..}) ->
-    cons func
-      <$> for
-        funcInfoParameters
-        ( \case
-            ATInteger -> AVExpr <$> genExpr
-            ATIntegerList -> AVListValues <$> genListValues
-        )
-
-genArg :: (MonadGen m) => m ArgValue
-genArg = Gen.choice [AVExpr <$> genExpr, AVListValues <$> genListValues]
-
-genBase :: (MonadGen m) => m Base
-genBase = Gen.frequency [(2, NBase <$> genNumBase), (2, DiceBase <$> genDice), (1, NumVar <$> genVarName)]
-
-genNumBase :: (MonadGen m) => m NumBase
-genNumBase =
-  Gen.recursive Gen.choice [Value <$> Gen.integral (Range.linear 0 100)] [NBParen . Paren <$> genExpr]
-
-genDice :: (MonadGen m) => m Dice
-genDice = Dice <$> genNumBase <*> genDie <*> Gen.list (Range.exponential 0 3) genDieOpOption
-
-genDie :: (MonadGen m) => m Die
-genDie = Gen.frequency (fmap (fmap (fmap MkDie)) strictDie <> [(1, MkDie . LazyDie <$> Gen.frequency strictDie)])
-  where
-    strictDie :: (MonadGen m) => [(Int, m (DieOf 'Strict))]
-    strictDie = [(3, Die <$> genNumBase), (1, CustomDie <$> genListValuesBase)]
-
-genDieOpOption :: (MonadGen m) => m DieOpOption
-genDieOpOption = Gen.choice (fmap (fmap MkDieOpOption) strictDieOp <> [MkDieOpOption . DieOpOptionLazy <$> Gen.choice strictDieOp])
-  where
-    strictDieOp :: (MonadGen m) => [m (DieOpOptionOf 'Strict)]
-    strictDieOp =
-      [ DieOpOptionKD
-          <$> Gen.element [Keep, Drop]
-          <*> Gen.frequency
-            [ (2, LH <$> Gen.element [Low, High] <*> genNumBase),
-              (1, Where <$> genAdvancedOrdering <*> genNumBase)
-            ],
-        Reroll <$> Gen.element [True, False] <*> genAdvancedOrdering <*> genNumBase
-      ]
-
-genAdvancedOrdering :: (MonadGen m) => m AdvancedOrdering
-genAdvancedOrdering = Gen.element $ fst advancedOrderingMapping
-
-genListValuesBase :: (MonadGen m) => m ListValuesBase
-genListValuesBase =
-  Gen.choice
-    [ LVBList <$> Gen.list (Range.exponential 1 10) genExpr,
-      LVBParen . Paren <$> genListValues
-    ]
-
-genListValues :: (MonadGen m) => m ListValues
-genListValues =
-  Gen.recursive
-    Gen.choice
-    [ LVVar . ("l_" <>) <$> genVarName
-    ]
-    [ MultipleValues <$> genNumBase <*> genBase,
-      LVBase <$> genListValuesBase,
-      ListValuesMisc <$> genMisc True genListValues,
-      functionGen LVFunc listFunctions
-    ]
 
 spec_roundtrip_dice :: Spec
 spec_roundtrip_dice = do

--- a/test/Dice/RoundtripSpec.hs
+++ b/test/Dice/RoundtripSpec.hs
@@ -8,16 +8,13 @@ import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import Test.Hspec.Hedgehog ()
-import Data.Kind
-import Text.Read
-import Tablebot.Plugins.Roll.Dice.DiceParsing
+import Tablebot.Plugins.Roll.Dice.DiceParsing ()
 import Tablebot.Plugins.Roll.Dice.DiceFunctions
 import Tablebot.Utility.SmartParser.SmartParser
 import Tablebot.Utility.Parser
 import Text.Megaparsec (runParser, eof)
 import Tablebot.Plugins.Roll.Dice.DiceData as Dice
 import qualified Data.Text as T
-import Control.Monad.IO.Class
 
 genExpr :: MonadGen m => m Expr
 genExpr =
@@ -115,6 +112,5 @@ spec_roundtrip_dice :: Spec
 spec_roundtrip_dice = do
   it "roundtrip dice" $ do
     dice <- forAll genExpr :: PropertyT IO Expr
-    liftIO $ print (parseShow dice)
     Right dice === runParser (pars <* eof) "" (parseShow dice)
 

--- a/test/Dice/RoundtripSpec.hs
+++ b/test/Dice/RoundtripSpec.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds #-}
+
+module Dice.RoundtripSpec where
+
+import Test.Hspec
+import Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import Test.Hspec.Hedgehog ()
+import Data.Kind
+import Text.Read
+import Tablebot.Plugins.Roll.Dice.DiceParsing
+import Tablebot.Plugins.Roll.Dice.DiceFunctions
+import Tablebot.Utility.SmartParser.SmartParser
+import Tablebot.Utility.Parser
+import Text.Megaparsec (runParser, eof)
+import Tablebot.Plugins.Roll.Dice.DiceData as Dice
+import qualified Data.Text as T
+import Control.Monad.IO.Class
+
+genExpr :: MonadGen m => m Expr
+genExpr =
+  Gen.recursive Gen.choice [Expr <$> genBin genTerm] [Gen.subtermM genExpr $ \expr -> ExprMisc <$> genMisc False (pure expr)]
+
+genMisc :: MonadGen m => Bool -> m a -> m (MiscData a)
+genMisc isList genA = Gen.choice [MiscIf <$> genIf genA, MiscVar <$> genVar isList genA]
+
+genIf :: MonadGen m => m a -> m (If a)
+genIf genA = If <$> genExpr <*> genA <*> genA
+
+genVarName :: MonadGen m => m T.Text
+genVarName = Gen.filterT (\var -> not $ any (`T.isPrefixOf` var) (integerFunctionsList <> listFunctionsList))
+  $ Gen.text (Range.linear 3 10) (Gen.element ['a'..'z'])
+
+genVar :: MonadGen m => Bool -> m a -> m (Dice.Var a)
+genVar isList genA =
+    Dice.Var
+      <$> ((if isList then ("l_" <>) else id) <$> genVarName)
+      <*> genA
+
+genBin :: (MonadGen m, Enum typ, Bounded typ) => m a -> m (BinOp a typ)
+genBin genA =
+  let opCount = Range.exponential 0 4
+  in BinOp
+    <$> genA
+    <*> Gen.list opCount ((,) <$> Gen.element [minBound..maxBound] <*> genA)
+
+genTerm :: MonadGen m => m Term
+genTerm = Term <$> genBin genNeg
+
+genNeg :: MonadGen m => m Negation
+genNeg = Gen.frequency [(2, NoNeg <$> genExpo), (1, Neg <$> genExpo)]
+
+genExpo :: MonadGen m => m Expo
+genExpo = 
+  Gen.recursive Gen.choice [NoExpo <$> genFunc] [Gen.subtermM genExpo (\expo -> (`Expo` expo) <$> genFunc )]
+
+genFunc :: MonadGen m => m Func
+genFunc = Gen.frequency
+  [ (5, NoFunc <$> genBase)
+  -- , (1, Func <$> Gen.element integerFunctions <*> Gen.list (Range.linear 1 2) genArg)
+  ]
+
+genArg :: MonadGen m => m ArgValue
+genArg = Gen.choice [AVExpr <$> genExpr, AVListValues <$> genListValues]
+
+genBase :: MonadGen m => m Base
+genBase = Gen.frequency [(2, NBase <$> genNumBase), (2, DiceBase <$> genDice), (1, NumVar <$> genVarName)]
+
+genNumBase :: MonadGen m => m NumBase
+genNumBase = 
+  Gen.recursive Gen.choice [Value <$> Gen.integral (Range.linear 0 100)] [NBParen . Paren <$> genExpr]
+
+genDice :: MonadGen m => m Dice
+genDice = Dice <$> genNumBase <*> genDie <*> Gen.list (Range.exponential 0 3) genDieOpOption
+
+genDie :: MonadGen m => m Die
+genDie = Gen.frequency (fmap (fmap (fmap MkDie)) strictDie <> [(1, MkDie . LazyDie <$> Gen.frequency strictDie)])
+  where
+  strictDie :: MonadGen m => [(Int, m (DieOf 'Strict))]
+  strictDie = [(3, Die <$> genNumBase), (1, CustomDie <$> genListValuesBase)]
+
+genDieOpOption :: MonadGen m => m DieOpOption
+genDieOpOption = Gen.choice (fmap (fmap MkDieOpOption) strictDieOp <> [MkDieOpOption . DieOpOptionLazy <$> Gen.choice strictDieOp])
+  where
+  strictDieOp :: MonadGen m => [m (DieOpOptionOf 'Strict)]
+  strictDieOp = 
+    [ DieOpOptionKD <$> Gen.element [Keep, Drop] <*> Gen.frequency
+      [ (2, Gen.element [Low, High] <*> genNumBase)
+      , (1, Where <$> genAdvancedOrdering <*> genNumBase)
+      ]
+    , Reroll <$> Gen.element [True, False] <*> genAdvancedOrdering <*> genNumBase
+    ]
+
+genAdvancedOrdering :: MonadGen m => m AdvancedOrdering
+genAdvancedOrdering = Gen.element $ fst advancedOrderingMapping
+
+genListValuesBase :: MonadGen m => m ListValuesBase
+genListValuesBase = Gen.choice
+  [ LVBList <$> Gen.list (Range.exponential 1 10) genExpr
+  , LVBParen . Paren <$> genListValues
+  ]
+
+genListValues :: MonadGen m => m ListValues
+genListValues = Gen.frequency
+  [ (4, MultipleValues <$> genNumBase <*> genBase)
+  , (2, LVBase <$> genListValuesBase)
+  , (2, ListValuesMisc <$> genMisc True genListValues)
+  -- , (1, LVFunc <$> Gen.element listFunctions <*> Gen.list (Range.linear 1 2) genArg)
+  , (1, LVVar . ("l_" <>) <$> genVarName)
+  ]
+
+spec_roundtrip_dice :: Spec
+spec_roundtrip_dice = do
+  it "roundtrip dice" $ do
+    dice <- forAll genExpr :: PropertyT IO Expr
+    liftIO $ print (parseShow dice)
+    Right dice === runParser (pars <* eof) "" (parseShow dice)
+

--- a/test/Dice/RoundtripSpec.hs
+++ b/test/Dice/RoundtripSpec.hs
@@ -87,7 +87,7 @@ genDieOpOption = Gen.choice (fmap (fmap MkDieOpOption) strictDieOp <> [MkDieOpOp
   strictDieOp :: MonadGen m => [m (DieOpOptionOf 'Strict)]
   strictDieOp = 
     [ DieOpOptionKD <$> Gen.element [Keep, Drop] <*> Gen.frequency
-      [ (2, Gen.element [Low, High] <*> genNumBase)
+      [ (2, LH <$> Gen.element [Low, High] <*> genNumBase)
       , (1, Where <$> genAdvancedOrdering <*> genNumBase)
       ]
     , Reroll <$> Gen.element [True, False] <*> genAdvancedOrdering <*> genNumBase

--- a/test/Dice/RoundtripSpec.hs
+++ b/test/Dice/RoundtripSpec.hs
@@ -1,128 +1,137 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Dice.RoundtripSpec where
 
-import Test.Hspec
+import qualified Data.Text as T
+import Data.Traversable
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import Test.Hspec.Hedgehog ()
-import Tablebot.Plugins.Roll.Dice.DiceParsing ()
-import Tablebot.Plugins.Roll.Dice.DiceFunctions
-import Tablebot.Utility.SmartParser.SmartParser
-import Tablebot.Utility.Parser
-import Text.Megaparsec (runParser, eof)
 import Tablebot.Plugins.Roll.Dice.DiceData as Dice
-import qualified Data.Text as T
-import Data.Traversable
+import Tablebot.Plugins.Roll.Dice.DiceFunctions
+import Tablebot.Plugins.Roll.Dice.DiceParsing ()
+import Tablebot.Utility.Parser
+import Tablebot.Utility.SmartParser.SmartParser
+import Test.Hspec
+import Test.Hspec.Hedgehog ()
+import Text.Megaparsec (eof, runParser)
 
-genExpr :: MonadGen m => m Expr
+genExpr :: (MonadGen m) => m Expr
 genExpr =
   Gen.recursive Gen.choice [Expr <$> genBin genTerm] [Gen.subtermM genExpr $ \expr -> ExprMisc <$> genMisc False (pure expr)]
 
-genMisc :: MonadGen m => Bool -> m a -> m (MiscData a)
+genMisc :: (MonadGen m) => Bool -> m a -> m (MiscData a)
 genMisc isList genA = Gen.choice [MiscIf <$> genIf genA, MiscVar <$> genVar isList genA]
 
-genIf :: MonadGen m => m a -> m (If a)
+genIf :: (MonadGen m) => m a -> m (If a)
 genIf genA = If <$> genExpr <*> genA <*> genA
 
-genVarName :: MonadGen m => m T.Text
-genVarName = Gen.filterT (\var -> not $ any (`T.isPrefixOf` var) (integerFunctionsList <> listFunctionsList))
-  $ Gen.text (Range.linear 3 10) (Gen.element ['a'..'z'])
+genVarName :: (MonadGen m) => m T.Text
+genVarName =
+  Gen.filterT (\var -> not $ any (`T.isPrefixOf` var) (integerFunctionsList <> listFunctionsList)) $
+    Gen.text (Range.linear 3 10) (Gen.element ['a' .. 'z'])
 
-genVar :: MonadGen m => Bool -> m a -> m (Dice.Var a)
+genVar :: (MonadGen m) => Bool -> m a -> m (Dice.Var a)
 genVar isList genA =
-    Dice.Var
-      <$> ((if isList then ("l_" <>) else id) <$> genVarName)
-      <*> genA
+  Dice.Var
+    <$> ((if isList then ("l_" <>) else id) <$> genVarName)
+    <*> genA
 
 genBin :: (MonadGen m, Enum typ, Bounded typ) => m a -> m (BinOp a typ)
 genBin genA =
   let opCount = Range.exponential 0 4
-  in BinOp
-    <$> genA
-    <*> Gen.list opCount ((,) <$> Gen.element [minBound..maxBound] <*> genA)
+   in BinOp
+        <$> genA
+        <*> Gen.list opCount ((,) <$> Gen.element [minBound .. maxBound] <*> genA)
 
-genTerm :: MonadGen m => m Term
+genTerm :: (MonadGen m) => m Term
 genTerm = Term <$> genBin genNeg
 
-genNeg :: MonadGen m => m Negation
+genNeg :: (MonadGen m) => m Negation
 genNeg = Gen.frequency [(2, NoNeg <$> genExpo), (1, Neg <$> genExpo)]
 
-genExpo :: MonadGen m => m Expo
-genExpo = 
-  Gen.recursive Gen.choice [NoExpo <$> genFunc] [Gen.subtermM genExpo (\expo -> (`Expo` expo) <$> genFunc )]
+genExpo :: (MonadGen m) => m Expo
+genExpo =
+  Gen.recursive Gen.choice [NoExpo <$> genFunc] [Gen.subtermM genExpo (\expo -> (`Expo` expo) <$> genFunc)]
 
-genFunc :: MonadGen m => m Func
-genFunc = Gen.frequency
-  [ (5, NoFunc <$> genBase)
-  , (1, functionGen Func integerFunctions)
-  ]
-
-functionGen :: (Foldable f, MonadGen m) => (FuncInfoBase j -> [ArgValue] -> r) -> f (FuncInfoBase j) -> m r
-functionGen cons functions = Gen.element functions >>= \func@(FuncInfo {..}) ->
-  cons func <$> for funcInfoParameters (\case
-    ATInteger -> AVExpr <$> genExpr
-    ATIntegerList -> AVListValues <$> genListValues
-    )
-
-genArg :: MonadGen m => m ArgValue
-genArg = Gen.choice [AVExpr <$> genExpr, AVListValues <$> genListValues]
-
-genBase :: MonadGen m => m Base
-genBase = Gen.frequency [(2, NBase <$> genNumBase), (2, DiceBase <$> genDice), (1, NumVar <$> genVarName)]
-
-genNumBase :: MonadGen m => m NumBase
-genNumBase = 
-  Gen.recursive Gen.choice [Value <$> Gen.integral (Range.linear 0 100)] [NBParen . Paren <$> genExpr]
-
-genDice :: MonadGen m => m Dice
-genDice = Dice <$> genNumBase <*> genDie <*> Gen.list (Range.exponential 0 3) genDieOpOption
-
-genDie :: MonadGen m => m Die
-genDie = Gen.frequency (fmap (fmap (fmap MkDie)) strictDie <> [(1, MkDie . LazyDie <$> Gen.frequency strictDie)])
-  where
-  strictDie :: MonadGen m => [(Int, m (DieOf 'Strict))]
-  strictDie = [(3, Die <$> genNumBase), (1, CustomDie <$> genListValuesBase)]
-
-genDieOpOption :: MonadGen m => m DieOpOption
-genDieOpOption = Gen.choice (fmap (fmap MkDieOpOption) strictDieOp <> [MkDieOpOption . DieOpOptionLazy <$> Gen.choice strictDieOp])
-  where
-  strictDieOp :: MonadGen m => [m (DieOpOptionOf 'Strict)]
-  strictDieOp = 
-    [ DieOpOptionKD <$> Gen.element [Keep, Drop] <*> Gen.frequency
-      [ (2, LH <$> Gen.element [Low, High] <*> genNumBase)
-      , (1, Where <$> genAdvancedOrdering <*> genNumBase)
-      ]
-    , Reroll <$> Gen.element [True, False] <*> genAdvancedOrdering <*> genNumBase
+genFunc :: (MonadGen m) => m Func
+genFunc =
+  Gen.frequency
+    [ (5, NoFunc <$> genBase),
+      (1, functionGen Func integerFunctions)
     ]
 
-genAdvancedOrdering :: MonadGen m => m AdvancedOrdering
+functionGen :: (Foldable f, MonadGen m) => (FuncInfoBase j -> [ArgValue] -> r) -> f (FuncInfoBase j) -> m r
+functionGen cons functions =
+  Gen.element functions >>= \func@(FuncInfo {..}) ->
+    cons func
+      <$> for
+        funcInfoParameters
+        ( \case
+            ATInteger -> AVExpr <$> genExpr
+            ATIntegerList -> AVListValues <$> genListValues
+        )
+
+genArg :: (MonadGen m) => m ArgValue
+genArg = Gen.choice [AVExpr <$> genExpr, AVListValues <$> genListValues]
+
+genBase :: (MonadGen m) => m Base
+genBase = Gen.frequency [(2, NBase <$> genNumBase), (2, DiceBase <$> genDice), (1, NumVar <$> genVarName)]
+
+genNumBase :: (MonadGen m) => m NumBase
+genNumBase =
+  Gen.recursive Gen.choice [Value <$> Gen.integral (Range.linear 0 100)] [NBParen . Paren <$> genExpr]
+
+genDice :: (MonadGen m) => m Dice
+genDice = Dice <$> genNumBase <*> genDie <*> Gen.list (Range.exponential 0 3) genDieOpOption
+
+genDie :: (MonadGen m) => m Die
+genDie = Gen.frequency (fmap (fmap (fmap MkDie)) strictDie <> [(1, MkDie . LazyDie <$> Gen.frequency strictDie)])
+  where
+    strictDie :: (MonadGen m) => [(Int, m (DieOf 'Strict))]
+    strictDie = [(3, Die <$> genNumBase), (1, CustomDie <$> genListValuesBase)]
+
+genDieOpOption :: (MonadGen m) => m DieOpOption
+genDieOpOption = Gen.choice (fmap (fmap MkDieOpOption) strictDieOp <> [MkDieOpOption . DieOpOptionLazy <$> Gen.choice strictDieOp])
+  where
+    strictDieOp :: (MonadGen m) => [m (DieOpOptionOf 'Strict)]
+    strictDieOp =
+      [ DieOpOptionKD
+          <$> Gen.element [Keep, Drop]
+          <*> Gen.frequency
+            [ (2, LH <$> Gen.element [Low, High] <*> genNumBase),
+              (1, Where <$> genAdvancedOrdering <*> genNumBase)
+            ],
+        Reroll <$> Gen.element [True, False] <*> genAdvancedOrdering <*> genNumBase
+      ]
+
+genAdvancedOrdering :: (MonadGen m) => m AdvancedOrdering
 genAdvancedOrdering = Gen.element $ fst advancedOrderingMapping
 
-genListValuesBase :: MonadGen m => m ListValuesBase
-genListValuesBase = Gen.choice
-  [ LVBList <$> Gen.list (Range.exponential 1 10) genExpr
-  , LVBParen . Paren <$> genListValues
-  ]
+genListValuesBase :: (MonadGen m) => m ListValuesBase
+genListValuesBase =
+  Gen.choice
+    [ LVBList <$> Gen.list (Range.exponential 1 10) genExpr,
+      LVBParen . Paren <$> genListValues
+    ]
 
-genListValues :: MonadGen m => m ListValues
+genListValues :: (MonadGen m) => m ListValues
 genListValues =
-  Gen.recursive Gen.choice 
+  Gen.recursive
+    Gen.choice
     [ LVVar . ("l_" <>) <$> genVarName
-      ]
-    [ MultipleValues <$> genNumBase <*> genBase
-    , LVBase <$> genListValuesBase
-    , ListValuesMisc <$> genMisc True genListValues
-    , functionGen LVFunc listFunctions
-      ]
+    ]
+    [ MultipleValues <$> genNumBase <*> genBase,
+      LVBase <$> genListValuesBase,
+      ListValuesMisc <$> genMisc True genListValues,
+      functionGen LVFunc listFunctions
+    ]
 
 spec_roundtrip_dice :: Spec
 spec_roundtrip_dice = do
   it "roundtrip dice" $ do
     dice <- forAll genExpr :: PropertyT IO Expr
     Right dice === runParser (pars <* eof) "" (parseShow dice)
-

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,1 @@
-main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+{-# OPTIONS_GHC -F -pgmF tasty-discover #-}


### PR DESCRIPTION
Lots of refactors, but the main part of this PR is using a sorted list instead of an unsorted list for a key in the distributions, which massively reduces on the number of realities we have to keep in mind.

I also add a test to verify that all dice we can show, we can parse.